### PR TITLE
Fix for VkParser

### DIFF
--- a/khrparser/vk/VKParser.py
+++ b/khrparser/vk/VKParser.py
@@ -285,6 +285,7 @@ class VKParser(XMLParser):
         binding.booleanType = profile.booleanType
         binding.booleanWidth = profile.booleanWidth
         binding.enumType = profile.enumType
+        binding.useEnumGroups = profile.useEnumGroups
         binding.bitfieldType = profile.bitfieldType
         binding.noneBitfieldValue = profile.noneBitfieldValue
         binding.cStringOutputTypes = profile.cStringOutputTypes


### PR DESCRIPTION
Script was failing with AttributeError: 'Binding' object has no attribute 'useEnumGroups' when run with vk.xml because it was not being assigned from the profile in VkParser.