### PR TITLE
Support for generating bindings for specifications which describe multiple APIs (OpenGL + OpenGL ES)

### DIFF
--- a/khrapi/API.py
+++ b/khrapi/API.py
@@ -3,10 +3,9 @@ from .Version import Version;
 from .Extension import Extension;
 
 class API(object):
-    def __init__(self, identifier, revision):
-        self.identifier = identifier
+    def __init__(self, name, revision):
+        self.name = name
         self.revision = revision
-        self.apis = []
         self.versions = []
         self.extensions = []
         self.types = []

--- a/khrapi/Version.py
+++ b/khrapi/Version.py
@@ -4,7 +4,7 @@ from .FeatureSet import FeatureSet
 class Version(FeatureSet):
     def __init__(self, api, internalIdentifier, identifier, versionString, apiString):
         super(Version, self).__init__(api, internalIdentifier)
-        self.nativeIdentifier = identifier
+        self.apiIdentifier = identifier
         self.apiString = apiString
         self.majorVersion, self.minorVersion = [ int(val) for val in versionString.split(".")[0:2] ]
         self.isCore = False

--- a/khrgenerator/cpp/CPPGenerator.py
+++ b/khrgenerator/cpp/CPPGenerator.py
@@ -283,16 +283,16 @@ class CPPGenerator:
         removedFunctions = set()
         currentFeature = None
         specialValueType = api.typeByIdentifier("SpecialValues")
-        apiString = ""
+        apiIdentifier = ""
         for feature, core, ext in cls.apiMemberSets(api, profile, api.versions):
-            if apiString != feature.apiString:
+            if apiIdentifier != feature.nativeIdentifier:
                 currentConstants = set()
                 currentFunctions = set()
                 deprecatedConstants = set()
                 deprecatedFunctions = set()
                 removedConstants = set()
                 removedFunctions = set()
-                apiString = feature.apiString
+                apiIdentifier = feature.nativeIdentifier
                 
             if currentFeature != feature: # apply changes
                 currentConstants |= set(feature.requiredConstants)
@@ -320,7 +320,7 @@ class CPPGenerator:
                 # Unfortunately, the API version required by the different extensions is only detailed in the different extension specifications and not the API specification XML.
                 # To further scope down the extensions to only the supported ones the extension specification XML files should be downloaded and parsed from the Khronos registry
                 # as well (https://registry.khronos.org/OpenGL/extensions).
-                supportedExtensions = [ extension for extension in api.extensions if len(extension.supportedAPIs) == 0 or (hasattr(feature, 'apiString') and feature.apiString in extension.supportedAPIs) ]
+                supportedExtensions = [ extension for extension in api.extensions if len(extension.supportedAPIs) == 0 or (apiIdentifier and apiIdentifier in extension.supportedAPIs) ]
                 constants = set()
                 functions = set()
                 for extension in supportedExtensions:

--- a/khrgenerator/cpp/CPPGenerator.py
+++ b/khrgenerator/cpp/CPPGenerator.py
@@ -18,12 +18,12 @@ from khrapi.CompoundType import CompoundType
 
 def performTypeNameNormalization(typeName):
     typeName = typeName.strip()
-    while typeName.startswith("const "):
-        typeName = typeName[6:].strip()
-    while typeName.endswith("*"):
-        typeName = typeName[:-1].strip()
-    while typeName.endswith("&"):
-        typeName = typeName[:-1].strip()
+    if typeName.startswith("const "):
+        return performTypeNameNormalization(typeName[6:])
+    if typeName.endswith("*"):
+        return performTypeNameNormalization(typeName[:-1])
+    if typeName.endswith("&"):
+        return performTypeNameNormalization(typeName[:-1])
     return typeName
 
 def getMinCoreVersionsLookup(profile):

--- a/khrgenerator/cpp/templates/AllVersions_test.cpp
+++ b/khrgenerator/cpp/templates/AllVersions_test.cpp
@@ -2,7 +2,7 @@
 #include <gmock/gmock.h>
 
 {% for version in versions|sort(attribute='identifier') %}
-#include <{{binding.identifier}}/{{ version.identifier }}/{{api.identifier}}.h>
+#include <{{binding.identifier}}/{{ version.identifier }}/{{binding.baseNamespace}}.h>
 {%- endfor %}
 
 

--- a/khrgenerator/cpp/templates/Binding_list.cpp
+++ b/khrgenerator/cpp/templates/Binding_list.cpp
@@ -2,7 +2,7 @@
 #include "Binding_pch.h"
 
 
-using namespace {{api.identifier}};
+using namespace {{binding.baseNamespace}};
 
 
 namespace {{binding.namespace}}

--- a/khrgenerator/cpp/templates/Binding_objects.cpp
+++ b/khrgenerator/cpp/templates/Binding_objects.cpp
@@ -2,7 +2,7 @@
 #include "Binding_pch.h"
 
 
-using namespace {{api.identifier}};
+using namespace {{binding.baseNamespace}};
 
 
 namespace {{binding.namespace}}

--- a/khrgenerator/cpp/templates/Meta.h
+++ b/khrgenerator/cpp/templates/Meta.h
@@ -11,7 +11,7 @@
 #include <{{binding.bindingAuxIdentifier}}/{{binding.bindingAuxIdentifier}}_api.h>
 #include <{{binding.bindingAuxIdentifier}}/{{binding.bindingAuxIdentifier}}_features.h>
 
-#include <{{binding.identifier}}/{{api.identifier}}/types.h>
+#include <{{binding.identifier}}/{{binding.baseNamespace}}/types.h>
 #include <{{binding.identifier}}/AbstractFunction.h>
 
 
@@ -46,7 +46,7 @@ public:
     *  @return
     *    The revision of the parsed {{profile.inputfile}} file
     */
-    static int {{api.identifier}}Revision();
+    static int {{binding.baseNamespace}}Revision();
 
     /**
     *  @brief
@@ -58,7 +58,7 @@ public:
     *  @return
     *    The symbol identified through the bitfield string, 0 if failed
     */
-    static {{api.identifier}}::{{binding.bitfieldType}} getBitfield(const std::string & bitfield);
+    static {{binding.baseNamespace}}::{{binding.bitfieldType}} getBitfield(const std::string & bitfield);
     
     /**
     *  @brief
@@ -67,13 +67,13 @@ public:
     *  @return
     *    The list of all bitfields known by the {{profile.inputfile}}
     */
-    static std::vector<{{api.identifier}}::{{binding.bitfieldType}}> bitfields();
+    static std::vector<{{binding.baseNamespace}}::{{binding.bitfieldType}}> bitfields();
 
     /**
     *  @brief
     *    Converts a {{binding.enumType}} to a string
     *
-    *  @param[in] {{api.identifier}}enum
+    *  @param[in] {{binding.baseNamespace}}enum
     *    The enum to convert
     *
     *  @return
@@ -82,19 +82,19 @@ public:
     *  @remark
     *    Beware, that some enums in the OpenGL API have different symbol names but identical enum values and that this function cannot differentiate between them
     */
-    // static const std::string & getString({{api.identifier}}::{{binding.enumType}} {{api.identifier}}enum);
+    // static const std::string & getString({{binding.baseNamespace}}::{{binding.enumType}} {{binding.baseNamespace}}enum);
     
     /**
     *  @brief
     *    Converts a string to an enum symbol
     *
-    *  @param[in] {{api.identifier}}enum
+    *  @param[in] {{binding.baseNamespace}}enum
     *    The string representation of the enum
     *
     *  @return
     *    The symbol identified through the enum string, 0 if failed
     */
-    static {{api.identifier}}::{{binding.enumType}} getEnum(const std::string & {{api.identifier}}enum);
+    static {{binding.baseNamespace}}::{{binding.enumType}} getEnum(const std::string & {{binding.baseNamespace}}enum);
     
     /**
     *  @brief
@@ -103,22 +103,22 @@ public:
     *  @return
     *    The list of all enums known by the {{profile.inputfile}}
     */
-    static std::set<{{api.identifier}}::{{binding.enumType}}> enums();
+    static std::set<{{binding.baseNamespace}}::{{binding.enumType}}> enums();
 
     /**
     *  @brief
     *    Converts a {{binding.booleanType}} to a string
     *
-    *  @param[in] {{api.identifier}}boolean
+    *  @param[in] {{binding.baseNamespace}}boolean
     *    The boolean to convert
     *
     *  @return
     *    A string representation of the {{binding.booleanType}} symbol name
     *
     *  @remark
-    *    Can either be `{{api.identifier|upper}}_TRUE` or `{{api.identifier|upper}}_FALSE`
+    *    Can either be `{{binding.baseNamespace|upper}}_TRUE` or `{{binding.baseNamespace|upper}}_FALSE`
     */
-    static const std::string & getString(const {{api.identifier}}::{{binding.booleanType}} & {{api.identifier}}boolean);
+    static const std::string & getString(const {{binding.baseNamespace}}::{{binding.booleanType}} & {{binding.baseNamespace}}boolean);
     
     /**
     *  @brief
@@ -128,21 +128,21 @@ public:
     *    The string representation of the {{binding.booleanType}}
     *
     *  @return
-    *    The symbol identified through the boolean string, `{{api.identifier|upper}}_FALSE` if failed
+    *    The symbol identified through the boolean string, `{{binding.baseNamespace|upper}}_FALSE` if failed
     */
-    static {{api.identifier}}::{{binding.booleanType}} getBoolean(const std::string & boolean);
+    static {{binding.baseNamespace}}::{{binding.booleanType}} getBoolean(const std::string & boolean);
 
     /**
     *  @brief
     *    Converts a {{binding.extensionType}} to its string representation
     *
-    *  @param[in] {{api.identifier}}extension
+    *  @param[in] {{binding.baseNamespace}}extension
     *    The extension to convert
     *
     *  @return
     *    The string representation of the extension
     */
-    static const std::string & getString({{api.identifier}}::{{binding.extensionType}} {{api.identifier}}extension);
+    static const std::string & getString({{binding.baseNamespace}}::{{binding.extensionType}} {{binding.baseNamespace}}extension);
     
     /**
     *  @brief
@@ -154,7 +154,7 @@ public:
     *  @return
     *    The symbol identified through the extension string, 'UNKNOWN' if failed
     */
-    static {{api.identifier}}::{{binding.extensionType}} getExtension(const std::string & extension);
+    static {{binding.baseNamespace}}::{{binding.extensionType}} getExtension(const std::string & extension);
 
     /**
     *  @brief
@@ -163,7 +163,7 @@ public:
     *  @return
     *    The set of all extensions known by the {{profile.inputfile}}
     */
-    static std::set<{{api.identifier}}::{{binding.extensionType}}> extensions();
+    static std::set<{{binding.baseNamespace}}::{{binding.extensionType}}> extensions();
     
     /**
     *  @brief
@@ -178,31 +178,31 @@ public:
     *    The set of extensions that should be supported for the given version.
     *    All non-versioned extensions can be queried by providing the null version
     */
-    static const std::set<{{api.identifier}}::{{binding.extensionType}}> extensions(const Version & version);
+    static const std::set<{{binding.baseNamespace}}::{{binding.extensionType}}> extensions(const Version & version);
 
     /**
     *  @brief
     *    Returns the list of extensions that are requiring a function
     *
     *  @param[in] function
-    *    The name of the function, including the '{{api.identifier}}' prefix
+    *    The name of the function, including the '{{binding.baseNamespace}}' prefix
     *
     *  @return
     *    The set of extensions that are requiring a function
     */
-    static const std::set<{{api.identifier}}::{{binding.extensionType}}> extensions(const std::string & {{api.identifier}}function);
+    static const std::set<{{binding.baseNamespace}}::{{binding.extensionType}}> extensions(const std::string & {{binding.baseNamespace}}function);
 
     /**
     *  @brief
     *    Returns the list of features that are requiring a function
     *
     *  @param[in] function
-    *    The name of the function, including the '{{api.identifier}}' prefix
+    *    The name of the function, including the '{{binding.baseNamespace}}' prefix
     *
     *  @return
     *    The set of features that are requiring a function
     */
-    static const std::set<Version> versions(const std::string & {{api.identifier}}function);
+    static const std::set<Version> versions(const std::string & {{binding.baseNamespace}}function);
     
     /**
     *  @brief
@@ -229,19 +229,19 @@ public:
     *  @return
     *    The set of functions that are required for the extension
     */
-    static const std::set<AbstractFunction *> functions({{api.identifier}}::{{binding.extensionType}} extension);
+    static const std::set<AbstractFunction *> functions({{binding.baseNamespace}}::{{binding.extensionType}} extension);
 
     /**
     *  @brief
     *    Returns the first Version (Feature) that required the extension
     *
-    *  @param[in] {{api.identifier}}extension
+    *  @param[in] {{binding.baseNamespace}}extension
     *    The extension
     *
     *  @return
     *    The first Version (Feature) that required the extension
     */
-    static const Version & version({{api.identifier}}::{{binding.extensionType}} {{api.identifier}}extension);
+    static const Version & version({{binding.baseNamespace}}::{{binding.extensionType}} {{binding.baseNamespace}}extension);
     
     /**
     *  @brief
@@ -256,20 +256,20 @@ public:
     *  @brief
     *    Convert bitfield to symbol name string representation
     *
-    *  @param[in] {{api.identifierl}}bitfield
+    *  @param[in] {{binding.baseNamespacel}}bitfield
     *    The bitfield value
     *
     *  @return
     *    The string representation of the value
     */
-    static const std::string & getString({{api.identifier}}::{{group.identifier}} {{api.identifier}}bitfield);
+    static const std::string & getString({{binding.baseNamespace}}::{{group.identifier}} {{binding.baseNamespace}}bitfield);
 {% endfor %}
 {% for group in enumGroups|sort(attribute='identifier') %}
     /**
     *  @brief
     *    Convert enum to symbol name string representation
     *
-    *  @param[in] {{api.identifierl}}enum
+    *  @param[in] {{binding.baseNamespacel}}enum
     *    The enum value
     *
     *  @return
@@ -278,19 +278,19 @@ public:
     *  @remark
     *    Beware, that some enums in the API have different symbol names but identical enum values and that this function cannot differentiate between them
     */
-    static const std::string & getString({{api.identifier}}::{{group.identifier}} {{api.identifier}}enum);
+    static const std::string & getString({{binding.baseNamespace}}::{{group.identifier}} {{binding.baseNamespace}}enum);
 
     /**
     *  @brief
     *    Convert enum to symbol name string representation
     *
-    *  @param[in] {{api.identifierl}}enum
+    *  @param[in] {{binding.baseNamespacel}}enum
     *    The enum value
     *
     *  @return
     *    All string representations of the value
     */
-    static std::vector<std::string> getStrings({{api.identifier}}::{{group.identifier}} {{api.identifier}}enum);
+    static std::vector<std::string> getStrings({{binding.baseNamespace}}::{{group.identifier}} {{binding.baseNamespace}}enum);
 {% endfor %}
 
 private:
@@ -302,7 +302,7 @@ private:
     *    The identifier for the bucket lookup
     *
     *  @param[in] prefixLength
-    *    The length of the prefix (e.g., '{{api.identifier}}' or '{{api.identifier|upper}}_') to omit to get the actual first character of the identifier
+    *    The length of the prefix (e.g., '{{binding.baseNamespace}}' or '{{binding.baseNamespace|upper}}_') to omit to get the actual first character of the identifier
     *
     *  @return
     *    The bucket index of an identifier

--- a/khrgenerator/cpp/templates/Meta_BitfieldsByString.cpp
+++ b/khrgenerator/cpp/templates/Meta_BitfieldsByString.cpp
@@ -1,10 +1,10 @@
 
 #include "Meta_Maps.h"
 
-#include <{{binding.identifier}}/{{api.identifier}}/bitfield.h>
+#include <{{binding.identifier}}/{{binding.baseNamespace}}/bitfield.h>
 
 
-using namespace {{api.identifier}};
+using namespace {{binding.baseNamespace}};
 
 
 namespace {{binding.namespace}} { namespace {{binding.auxNamespace}}
@@ -23,7 +23,7 @@ const std::unordered_map<std::string, {{binding.bitfieldType}}> Meta_BitfieldsBy
 };
 {%- endif %}
 {% endfor %}
-const std::array<std::unordered_map<std::string, {{api.identifier}}::{{binding.bitfieldType}}>, {{groups|length}}> Meta_BitfieldsByStringMaps =
+const std::array<std::unordered_map<std::string, {{binding.baseNamespace}}::{{binding.bitfieldType}}>, {{groups|length}}> Meta_BitfieldsByStringMaps =
 { {
 {%- for groupname, constants in groups|dictsort %}
     Meta_BitfieldsByString_{{groupname}}{% if not loop.last %},{% endif %}

--- a/khrgenerator/cpp/templates/Meta_BooleansByString.cpp
+++ b/khrgenerator/cpp/templates/Meta_BooleansByString.cpp
@@ -1,10 +1,10 @@
 
 #include "Meta_Maps.h"
 
-#include <{{binding.identifier}}/{{api.identifier}}/boolean.h>
+#include <{{binding.identifier}}/{{binding.baseNamespace}}/boolean.h>
 
 
-using namespace {{api.identifier}};
+using namespace {{binding.baseNamespace}};
 
 
 namespace {{binding.namespace}} { namespace {{binding.auxNamespace}}
@@ -14,7 +14,7 @@ namespace {{binding.namespace}} { namespace {{binding.auxNamespace}}
 const std::unordered_map<std::string, {{binding.booleanType}}> Meta_BooleansByString =
 {
 {%- for boolean in booleans|sort(attribute='identifier') %}
-    { "{{boolean.identifier}}", {{api.identifier}}::{{boolean.identifier}} }{% if not loop.last %},{% endif %}
+    { "{{boolean.identifier}}", {{binding.baseNamespace}}::{{boolean.identifier}} }{% if not loop.last %},{% endif %}
 {%- endfor %}
 };
 

--- a/khrgenerator/cpp/templates/Meta_EnumsByString.cpp
+++ b/khrgenerator/cpp/templates/Meta_EnumsByString.cpp
@@ -1,10 +1,10 @@
 
 #include "Meta_Maps.h"
 
-#include <{{binding.identifier}}/{{api.identifier}}/enum.h>
+#include <{{binding.identifier}}/{{binding.baseNamespace}}/enum.h>
 
 
-using namespace {{api.identifier}};
+using namespace {{binding.baseNamespace}};
 
 
 namespace {{binding.namespace}} { namespace {{binding.auxNamespace}}
@@ -22,7 +22,7 @@ const std::unordered_map<std::string, {{binding.enumType}}> Meta_EnumsByString_{
 };
 {%- endif %}
 {% endfor %}
-const std::array<std::unordered_map<std::string, {{api.identifier}}::{{binding.enumType}}>, {{groups|length}}> Meta_EnumsByStringMaps =
+const std::array<std::unordered_map<std::string, {{binding.baseNamespace}}::{{binding.enumType}}>, {{groups|length}}> Meta_EnumsByStringMaps =
 { {
 {%- for groupname, constants in groups|dictsort %}
     Meta_EnumsByString_{{groupname}}{% if not loop.last %},{% endif %}

--- a/khrgenerator/cpp/templates/Meta_ExtensionsByFunctionString.cpp
+++ b/khrgenerator/cpp/templates/Meta_ExtensionsByFunctionString.cpp
@@ -1,10 +1,10 @@
 
 #include "Meta_Maps.h"
 
-#include <{{binding.identifier}}/{{api.identifier}}/extension.h>
+#include <{{binding.identifier}}/{{binding.baseNamespace}}/extension.h>
 
 
-using namespace {{api.identifier}};
+using namespace {{binding.baseNamespace}};
 
 
 namespace {{binding.namespace}} { namespace {{binding.auxNamespace}}
@@ -21,7 +21,7 @@ const std::unordered_map<std::string, std::set<{{binding.extensionType}}>> Meta_
 {%- endif %}{% endfor %}
 };
 {% endif %}{% endfor %}
-const std::array<std::unordered_map<std::string, std::set<{{api.identifier}}::{{binding.extensionType}}>>, {{extensionsByFunction|length}}> Meta_ExtensionsByFunctionStringMaps =
+const std::array<std::unordered_map<std::string, std::set<{{binding.baseNamespace}}::{{binding.extensionType}}>>, {{extensionsByFunction|length}}> Meta_ExtensionsByFunctionStringMaps =
 { {
 {%- for groupname, function in extensionsByFunction|dictsort %}
     Meta_ExtensionsByFunctionString_{{groupname}}{{ "," if not loop.last }}

--- a/khrgenerator/cpp/templates/Meta_ExtensionsByString.cpp
+++ b/khrgenerator/cpp/templates/Meta_ExtensionsByString.cpp
@@ -1,10 +1,10 @@
 
 #include "Meta_Maps.h"
 
-#include <{{binding.identifier}}/{{api.identifier}}/extension.h>
+#include <{{binding.identifier}}/{{binding.baseNamespace}}/extension.h>
 
 
-using namespace {{api.identifier}};
+using namespace {{binding.baseNamespace}};
 
 
 namespace {{binding.namespace}} { namespace {{binding.auxNamespace}}
@@ -23,7 +23,7 @@ const std::unordered_map<std::string, {{binding.extensionType}}> Meta_Extensions
 };
 {% endif %}
 {% endfor -%}
-const std::array<std::unordered_map<std::string, {{api.identifier}}::{{binding.extensionType}}>, {{groups|length}}> Meta_ExtensionsByStringMaps =
+const std::array<std::unordered_map<std::string, {{binding.baseNamespace}}::{{binding.extensionType}}>, {{groups|length}}> Meta_ExtensionsByStringMaps =
 { {
 {%- for groupname, extensions in groups|dictsort %}
     Meta_ExtensionsByString_{{groupname}}{{ "," if not loop.last }}

--- a/khrgenerator/cpp/templates/Meta_FunctionStringsByExtension.cpp
+++ b/khrgenerator/cpp/templates/Meta_FunctionStringsByExtension.cpp
@@ -1,10 +1,10 @@
 
 #include "Meta_Maps.h"
 
-#include <{{binding.identifier}}/{{api.identifier}}/extension.h>
+#include <{{binding.identifier}}/{{binding.baseNamespace}}/extension.h>
 
 
-using namespace {{api.identifier}};
+using namespace {{binding.baseNamespace}};
 
 
 namespace {{binding.namespace}} { namespace {{binding.auxNamespace}}

--- a/khrgenerator/cpp/templates/Meta_FunctionStringsByVersion.cpp
+++ b/khrgenerator/cpp/templates/Meta_FunctionStringsByVersion.cpp
@@ -4,7 +4,7 @@
 #include <{{binding.identifier}}/Version.h>
 
 
-using namespace {{api.identifier}};
+using namespace {{binding.baseNamespace}};
 
 
 namespace {{binding.namespace}} { namespace {{binding.auxNamespace}}

--- a/khrgenerator/cpp/templates/Meta_Maps.h
+++ b/khrgenerator/cpp/templates/Meta_Maps.h
@@ -9,8 +9,8 @@
 #include <set>
 #include <array>
 
-#include <{{binding.identifier}}/{{api.identifier}}/types.h>
-#include <{{binding.identifier}}/{{api.identifier}}/extension.h>
+#include <{{binding.identifier}}/{{binding.baseNamespace}}/types.h>
+#include <{{binding.identifier}}/{{binding.baseNamespace}}/extension.h>
 
 
 namespace {{binding.namespace}}
@@ -24,25 +24,25 @@ namespace {{binding.auxNamespace}}
 {
 
 
-extern const std::array<std::unordered_map<std::string, {{api.identifier}}::{{binding.extensionType}}>, 27> Meta_ExtensionsByStringMaps;
-extern const std::unordered_map<{{api.identifier}}::{{binding.extensionType}}, Version> Meta_ReqVersionsByExtension;
+extern const std::array<std::unordered_map<std::string, {{binding.baseNamespace}}::{{binding.extensionType}}>, 27> Meta_ExtensionsByStringMaps;
+extern const std::unordered_map<{{binding.baseNamespace}}::{{binding.extensionType}}, Version> Meta_ReqVersionsByExtension;
 
-extern const std::unordered_map<{{api.identifier}}::{{binding.booleanType}}, std::string> Meta_StringsByBoolean;
-extern const std::multimap<{{api.identifier}}::{{binding.enumType}}, std::string> Meta_StringsByEnum;
-extern const std::unordered_map<{{api.identifier}}::{{binding.extensionType}}, std::string> Meta_StringsByExtension;
-extern const std::unordered_map<{{api.identifier}}::{{binding.extensionType}}, std::set<std::string>> Meta_FunctionStringsByExtension;
+extern const std::unordered_map<{{binding.baseNamespace}}::{{binding.booleanType}}, std::string> Meta_StringsByBoolean;
+extern const std::multimap<{{binding.baseNamespace}}::{{binding.enumType}}, std::string> Meta_StringsByEnum;
+extern const std::unordered_map<{{binding.baseNamespace}}::{{binding.extensionType}}, std::string> Meta_StringsByExtension;
+extern const std::unordered_map<{{binding.baseNamespace}}::{{binding.extensionType}}, std::set<std::string>> Meta_FunctionStringsByExtension;
 extern const std::map<Version, std::set<std::string>> Meta_FunctionStringsByVersion;
 
 {% for group in bitfieldGroups|sort(attribute='identifier') -%}
-extern const std::unordered_map<{{api.identifier}}::{{group.identifier}}, std::string> Meta_StringsBy{{group.identifier}};
+extern const std::unordered_map<{{binding.baseNamespace}}::{{group.identifier}}, std::string> Meta_StringsBy{{group.identifier}};
 {% endfor %}
 {% for group in enumGroups|sort(attribute='identifier') -%}
-extern const std::unordered_map<{{api.identifier}}::{{group.identifier}}, std::string> Meta_StringsBy{{group.identifier}};
+extern const std::unordered_map<{{binding.baseNamespace}}::{{group.identifier}}, std::string> Meta_StringsBy{{group.identifier}};
 {% endfor %}
-extern const std::array<std::unordered_map<std::string, {{api.identifier}}::{{binding.bitfieldType}}>, 27> Meta_BitfieldsByStringMaps;
-extern const std::unordered_map<std::string, {{api.identifier}}::{{binding.booleanType}}> Meta_BooleansByString;
-extern const std::array<std::unordered_map<std::string, {{api.identifier}}::{{binding.enumType}}>, 27> Meta_EnumsByStringMaps;
-extern const std::array<std::unordered_map<std::string, std::set<{{api.identifier}}::{{binding.extensionType}}>>, 27> Meta_ExtensionsByFunctionStringMaps;
+extern const std::array<std::unordered_map<std::string, {{binding.baseNamespace}}::{{binding.bitfieldType}}>, 27> Meta_BitfieldsByStringMaps;
+extern const std::unordered_map<std::string, {{binding.baseNamespace}}::{{binding.booleanType}}> Meta_BooleansByString;
+extern const std::array<std::unordered_map<std::string, {{binding.baseNamespace}}::{{binding.enumType}}>, 27> Meta_EnumsByStringMaps;
+extern const std::array<std::unordered_map<std::string, std::set<{{binding.baseNamespace}}::{{binding.extensionType}}>>, 27> Meta_ExtensionsByFunctionStringMaps;
 
 
 } } // namespace {{binding.bindingAuxNamespace}}

--- a/khrgenerator/cpp/templates/Meta_ReqVersionsByExtension.cpp
+++ b/khrgenerator/cpp/templates/Meta_ReqVersionsByExtension.cpp
@@ -1,11 +1,11 @@
 
 #include "Meta_Maps.h"
 
-#include <{{binding.identifier}}/{{api.identifier}}/extension.h>
+#include <{{binding.identifier}}/{{binding.baseNamespace}}/extension.h>
 #include <{{binding.identifier}}/Version.h>
 
 
-using namespace {{api.identifier}};
+using namespace {{binding.baseNamespace}};
 
 
 namespace {{binding.namespace}} { namespace {{binding.auxNamespace}}

--- a/khrgenerator/cpp/templates/Meta_StringsByBitfield.cpp
+++ b/khrgenerator/cpp/templates/Meta_StringsByBitfield.cpp
@@ -1,10 +1,10 @@
 
 #include "Meta_Maps.h"
 
-#include <{{binding.identifier}}/{{api.identifier}}/bitfield.h>
+#include <{{binding.identifier}}/{{binding.baseNamespace}}/bitfield.h>
 
 
-using namespace {{api.identifier}};
+using namespace {{binding.baseNamespace}};
 
 
 namespace {{binding.namespace}} { namespace {{binding.auxNamespace}}

--- a/khrgenerator/cpp/templates/Meta_StringsByBoolean.cpp
+++ b/khrgenerator/cpp/templates/Meta_StringsByBoolean.cpp
@@ -1,10 +1,10 @@
 
 #include "Meta_Maps.h"
 
-#include <{{binding.identifier}}/{{api.identifier}}/boolean.h>
+#include <{{binding.identifier}}/{{binding.baseNamespace}}/boolean.h>
 
 
-using namespace {{api.identifier}};
+using namespace {{binding.baseNamespace}};
 
 
 namespace {{binding.namespace}} { namespace {{binding.auxNamespace}}
@@ -14,7 +14,7 @@ namespace {{binding.namespace}} { namespace {{binding.auxNamespace}}
 const std::unordered_map<{{binding.booleanType}}, std::string> Meta_StringsByBoolean =
 {
 {%- for boolean in booleans|sort(attribute='identifier') %}
-    { {{api.identifier}}::{{boolean.identifier}}, "{{boolean.identifier}}" }{% if not loop.last %},{% endif %}
+    { {{binding.baseNamespace}}::{{boolean.identifier}}, "{{boolean.identifier}}" }{% if not loop.last %},{% endif %}
 {%- endfor %}
 };
 

--- a/khrgenerator/cpp/templates/Meta_StringsByEnum.cpp
+++ b/khrgenerator/cpp/templates/Meta_StringsByEnum.cpp
@@ -1,10 +1,10 @@
 
 #include "Meta_Maps.h"
 
-#include <{{binding.identifier}}/{{api.identifier}}/enum.h>
+#include <{{binding.identifier}}/{{binding.baseNamespace}}/enum.h>
 
 
-using namespace {{api.identifier}};
+using namespace {{binding.baseNamespace}};
 
 
 namespace {{binding.namespace}} { namespace {{binding.auxNamespace}}

--- a/khrgenerator/cpp/templates/Meta_StringsByExtension.cpp
+++ b/khrgenerator/cpp/templates/Meta_StringsByExtension.cpp
@@ -1,10 +1,10 @@
 
 #include "Meta_Maps.h"
 
-#include <{{binding.identifier}}/{{api.identifier}}/extension.h>
+#include <{{binding.identifier}}/{{binding.baseNamespace}}/extension.h>
 
 
-using namespace {{api.identifier}};
+using namespace {{binding.baseNamespace}};
 
 
 namespace {{binding.namespace}} { namespace {{binding.auxNamespace}}

--- a/khrgenerator/cpp/templates/Meta_getStringByBitfield.cpp
+++ b/khrgenerator/cpp/templates/Meta_getStringByBitfield.cpp
@@ -1,12 +1,12 @@
 
 #include <{{binding.bindingAuxIdentifier}}/Meta.h>
 
-#include <{{binding.identifier}}/{{api.identifier}}/bitfield.h>
+#include <{{binding.identifier}}/{{binding.baseNamespace}}/bitfield.h>
 
 #include "Meta_Maps.h"
 
 
-using namespace {{api.identifier}};
+using namespace {{binding.baseNamespace}};
 
 
 namespace
@@ -25,9 +25,9 @@ namespace {{binding.namespace}} { namespace {{binding.auxNamespace}}
 
 {% for group in groups|sort(attribute='identifier') -%}
 
-const std::string & Meta::getString(const {{group.identifier}} {{api.identifier}}bitfield)
+const std::string & Meta::getString(const {{group.identifier}} {{binding.baseNamespace}}bitfield)
 {
-    const auto i = Meta_StringsBy{{group.identifier}}.find({{api.identifier}}bitfield);
+    const auto i = Meta_StringsBy{{group.identifier}}.find({{binding.baseNamespace}}bitfield);
     if (i != Meta_StringsBy{{group.identifier}}.end())
     {
         return i->second;

--- a/khrgenerator/cpp/templates/bitfield.h
+++ b/khrgenerator/cpp/templates/bitfield.h
@@ -2,14 +2,14 @@
 #pragma once
 
 
-#include <{{binding.identifier}}/no{{api.identifier}}.h>
+#include <{{binding.identifier}}/no{{binding.baseNamespace}}.h>
 
 #include <{{binding.identifier}}/{{binding.identifier}}_features.h>
 
 #include <{{binding.identifier}}/SharedBitfield.h>
 
 
-namespace {{api.identifier}}
+namespace {{binding.baseNamespace}}
 {
 
 
@@ -36,4 +36,4 @@ enum class {{group.identifier}} : unsigned int
 {%- endif %}
 {% endfor %}
 
-} // namespace {{api.identifier}}
+} // namespace {{binding.baseNamespace}}

--- a/khrgenerator/cpp/templates/bitfieldF.h
+++ b/khrgenerator/cpp/templates/bitfieldF.h
@@ -2,9 +2,9 @@
 #pragma once
 
 
-#include <{{binding.identifier}}/no{{api.identifier}}.h>
+#include <{{binding.identifier}}/no{{binding.baseNamespace}}.h>
 
-#include <{{binding.identifier}}/{{api.identifier}}/bitfield.h>
+#include <{{binding.identifier}}/{{binding.baseNamespace}}/bitfield.h>
 
 
 namespace {{apiString}}{{memberSet}}
@@ -13,7 +13,7 @@ namespace {{apiString}}{{memberSet}}
 
 // import bitfields to namespace
 {%- for constant in constants|sort(attribute='identifier') %}
-using {{api.identifier}}::{{constant.identifier}};
+using {{binding.baseNamespace}}::{{constant.identifier}};
 {%- endfor %}
 
 

--- a/khrgenerator/cpp/templates/bitfieldF.h
+++ b/khrgenerator/cpp/templates/bitfieldF.h
@@ -7,7 +7,7 @@
 #include <{{binding.identifier}}/{{api.identifier}}/bitfield.h>
 
 
-namespace {{api.identifier}}{{memberSet}}
+namespace {{apiString}}{{memberSet}}
 {
 
 
@@ -17,4 +17,4 @@ using {{api.identifier}}::{{constant.identifier}};
 {%- endfor %}
 
 
-} // namespace {{api.identifier}}{{memberSet}}
+} // namespace {{apiString}}{{memberSet}}

--- a/khrgenerator/cpp/templates/boolean.h
+++ b/khrgenerator/cpp/templates/boolean.h
@@ -6,10 +6,10 @@
 
 #include <{{binding.identifier}}/{{binding.identifier}}_api.h>
 #include <{{binding.identifier}}/{{binding.identifier}}_features.h>
-#include <{{binding.identifier}}/no{{api.identifier}}.h>
+#include <{{binding.identifier}}/no{{binding.baseNamespace}}.h>
 
 
-namespace {{api.identifier}}
+namespace {{binding.baseNamespace}}
 {
 
 
@@ -22,4 +22,4 @@ using {{binding.booleanType}} = {{binding.identifier}}::{{nativeType}};
 {{binding.constexpr}} static const {{binding.booleanType}} {{constant.identifier}} = {{binding.booleanType}}({{constant.value}});
 {% endfor %}
 
-} // namespace {{api.identifier}}
+} // namespace {{binding.baseNamespace}}

--- a/khrgenerator/cpp/templates/booleanF.h
+++ b/khrgenerator/cpp/templates/booleanF.h
@@ -7,7 +7,7 @@
 #include <{{api.identifier}}binding/{{api.identifier}}/boolean.h>
 
 
-namespace {{api.identifier}}{{memberSet}}
+namespace {{apiString}}{{memberSet}}
 {
 
 
@@ -21,4 +21,4 @@ using {{api.identifier}}::{{constant.identifier}};
 {%- endfor %}
 
 
-} // namespace {{api.identifier}}{{memberSet}}
+} // namespace {{apiString}}{{memberSet}}

--- a/khrgenerator/cpp/templates/booleanF.h
+++ b/khrgenerator/cpp/templates/booleanF.h
@@ -2,9 +2,9 @@
 #pragma once
 
 
-#include <{{api.identifier}}binding/no{{api.identifier}}.h>
+#include <{{binding.baseNamespace}}binding/no{{binding.baseNamespace}}.h>
 
-#include <{{api.identifier}}binding/{{api.identifier}}/boolean.h>
+#include <{{binding.baseNamespace}}binding/{{binding.baseNamespace}}/boolean.h>
 
 
 namespace {{apiString}}{{memberSet}}
@@ -12,12 +12,12 @@ namespace {{apiString}}{{memberSet}}
 
 
 // use boolean type
-using {{api.identifier}}::{{binding.booleanType}};
+using {{binding.baseNamespace}}::{{binding.booleanType}};
 
 
 // import booleans to namespace
 {%- for constant in constants|sort(attribute='identifier') %}
-using {{api.identifier}}::{{constant.identifier}};
+using {{binding.baseNamespace}}::{{constant.identifier}};
 {%- endfor %}
 
 

--- a/khrgenerator/cpp/templates/booleanF.h
+++ b/khrgenerator/cpp/templates/booleanF.h
@@ -2,9 +2,9 @@
 #pragma once
 
 
-#include <{{binding.baseNamespace}}binding/no{{binding.baseNamespace}}.h>
+#include <{{profile.bindingNamespace}}/no{{binding.baseNamespace}}.h>
 
-#include <{{binding.baseNamespace}}binding/{{binding.baseNamespace}}/boolean.h>
+#include <{{profile.bindingNamespace}}/{{binding.baseNamespace}}/boolean.h>
 
 
 namespace {{apiString}}{{memberSet}}

--- a/khrgenerator/cpp/templates/entrypoint.h
+++ b/khrgenerator/cpp/templates/entrypoint.h
@@ -2,12 +2,12 @@
 #pragma once
 
 
-#include <{{binding.identifier}}/no{{api.identifier}}.h>
+#include <{{binding.identifier}}/no{{binding.baseNamespace}}.h>
 
-#include <{{binding.identifier}}/{{api.identifier}}/extension.h>
-#include <{{binding.identifier}}/{{api.identifier}}/types.h>
-#include <{{binding.identifier}}/{{api.identifier}}/boolean.h>
-#include <{{binding.identifier}}/{{api.identifier}}/values.h>
-#include <{{binding.identifier}}/{{api.identifier}}/bitfield.h>
-#include <{{binding.identifier}}/{{api.identifier}}/enum.h>
-#include <{{binding.identifier}}/{{api.identifier}}/functions.h>
+#include <{{binding.identifier}}/{{binding.baseNamespace}}/extension.h>
+#include <{{binding.identifier}}/{{binding.baseNamespace}}/types.h>
+#include <{{binding.identifier}}/{{binding.baseNamespace}}/boolean.h>
+#include <{{binding.identifier}}/{{binding.baseNamespace}}/values.h>
+#include <{{binding.identifier}}/{{binding.baseNamespace}}/bitfield.h>
+#include <{{binding.identifier}}/{{binding.baseNamespace}}/enum.h>
+#include <{{binding.identifier}}/{{binding.baseNamespace}}/functions.h>

--- a/khrgenerator/cpp/templates/entrypointF.h
+++ b/khrgenerator/cpp/templates/entrypointF.h
@@ -2,13 +2,13 @@
 #pragma once
 
 
-#include <{{api.identifier}}binding/no{{api.identifier}}.h>
+#include <{{binding.baseNamespace}}binding/no{{binding.baseNamespace}}.h>
 
-#include <{{api.identifier}}binding/{{apiString}}{{memberSet}}/types.h>
-#include <{{api.identifier}}binding/{{apiString}}{{memberSet}}/values.h>
-#include <{{api.identifier}}binding/{{apiString}}{{memberSet}}/boolean.h>
-#include <{{api.identifier}}binding/{{apiString}}{{memberSet}}/bitfield.h>
-#include <{{api.identifier}}binding/{{apiString}}{{memberSet}}/enum.h>
-#include <{{api.identifier}}binding/{{apiString}}{{memberSet}}/functions.h>
+#include <{{binding.baseNamespace}}binding/{{apiString}}{{memberSet}}/types.h>
+#include <{{binding.baseNamespace}}binding/{{apiString}}{{memberSet}}/values.h>
+#include <{{binding.baseNamespace}}binding/{{apiString}}{{memberSet}}/boolean.h>
+#include <{{binding.baseNamespace}}binding/{{apiString}}{{memberSet}}/bitfield.h>
+#include <{{binding.baseNamespace}}binding/{{apiString}}{{memberSet}}/enum.h>
+#include <{{binding.baseNamespace}}binding/{{apiString}}{{memberSet}}/functions.h>
 
-#include <{{api.identifier}}binding/{{api.identifier}}/extension.h>
+#include <{{binding.baseNamespace}}binding/{{binding.baseNamespace}}/extension.h>

--- a/khrgenerator/cpp/templates/entrypointF.h
+++ b/khrgenerator/cpp/templates/entrypointF.h
@@ -4,11 +4,11 @@
 
 #include <{{api.identifier}}binding/no{{api.identifier}}.h>
 
-#include <{{api.identifier}}binding/{{api.identifier}}{{memberSet}}/types.h>
-#include <{{api.identifier}}binding/{{api.identifier}}{{memberSet}}/values.h>
-#include <{{api.identifier}}binding/{{api.identifier}}{{memberSet}}/boolean.h>
-#include <{{api.identifier}}binding/{{api.identifier}}{{memberSet}}/bitfield.h>
-#include <{{api.identifier}}binding/{{api.identifier}}{{memberSet}}/enum.h>
-#include <{{api.identifier}}binding/{{api.identifier}}{{memberSet}}/functions.h>
+#include <{{api.identifier}}binding/{{apiString}}{{memberSet}}/types.h>
+#include <{{api.identifier}}binding/{{apiString}}{{memberSet}}/values.h>
+#include <{{api.identifier}}binding/{{apiString}}{{memberSet}}/boolean.h>
+#include <{{api.identifier}}binding/{{apiString}}{{memberSet}}/bitfield.h>
+#include <{{api.identifier}}binding/{{apiString}}{{memberSet}}/enum.h>
+#include <{{api.identifier}}binding/{{apiString}}{{memberSet}}/functions.h>
 
 #include <{{api.identifier}}binding/{{api.identifier}}/extension.h>

--- a/khrgenerator/cpp/templates/entrypointF.h
+++ b/khrgenerator/cpp/templates/entrypointF.h
@@ -2,13 +2,13 @@
 #pragma once
 
 
-#include <{{binding.baseNamespace}}binding/no{{binding.baseNamespace}}.h>
+#include <{{profile.bindingNamespace}}/no{{binding.baseNamespace}}.h>
 
-#include <{{binding.baseNamespace}}binding/{{apiString}}{{memberSet}}/types.h>
-#include <{{binding.baseNamespace}}binding/{{apiString}}{{memberSet}}/values.h>
-#include <{{binding.baseNamespace}}binding/{{apiString}}{{memberSet}}/boolean.h>
-#include <{{binding.baseNamespace}}binding/{{apiString}}{{memberSet}}/bitfield.h>
-#include <{{binding.baseNamespace}}binding/{{apiString}}{{memberSet}}/enum.h>
-#include <{{binding.baseNamespace}}binding/{{apiString}}{{memberSet}}/functions.h>
+#include <{{profile.bindingNamespace}}/{{apiString}}{{memberSet}}/types.h>
+#include <{{profile.bindingNamespace}}/{{apiString}}{{memberSet}}/values.h>
+#include <{{profile.bindingNamespace}}/{{apiString}}{{memberSet}}/boolean.h>
+#include <{{profile.bindingNamespace}}/{{apiString}}{{memberSet}}/bitfield.h>
+#include <{{profile.bindingNamespace}}/{{apiString}}{{memberSet}}/enum.h>
+#include <{{profile.bindingNamespace}}/{{apiString}}{{memberSet}}/functions.h>
 
-#include <{{binding.baseNamespace}}binding/{{binding.baseNamespace}}/extension.h>
+#include <{{profile.bindingNamespace}}/{{binding.baseNamespace}}/extension.h>

--- a/khrgenerator/cpp/templates/enum.h
+++ b/khrgenerator/cpp/templates/enum.h
@@ -2,12 +2,12 @@
 #pragma once
 
 
-#include <{{binding.identifier}}/no{{api.identifier}}.h>
+#include <{{binding.identifier}}/no{{binding.baseNamespace}}.h>
 
 #include <{{binding.identifier}}/{{binding.identifier}}_features.h>
 
 
-namespace {{api.identifier}}
+namespace {{binding.baseNamespace}}
 {
 
 
@@ -42,4 +42,4 @@ enum class {{binding.enumType}} : unsigned int
 {% endfor %}
 {% endfor %}
 
-} // namespace {{api.identifier}}
+} // namespace {{binding.baseNamespace}}

--- a/khrgenerator/cpp/templates/enumF.h
+++ b/khrgenerator/cpp/templates/enumF.h
@@ -2,9 +2,9 @@
 #pragma once
 
 
-#include <{{api.identifier}}binding/no{{api.identifier}}.h>
+#include <{{binding.baseNamespace}}binding/no{{binding.baseNamespace}}.h>
 
-#include <{{api.identifier}}binding/{{api.identifier}}/enum.h>
+#include <{{binding.baseNamespace}}binding/{{binding.baseNamespace}}/enum.h>
 
 
 namespace {{apiString}}{{memberSet}}
@@ -12,12 +12,12 @@ namespace {{apiString}}{{memberSet}}
 
 
 // use enum type
-using {{api.identifier}}::{{binding.enumType}};
+using {{binding.baseNamespace}}::{{binding.enumType}};
 
 
 // import enums to namespace
 {%- for constant in constants|sort(attribute='identifier') %}
-using {{api.identifier}}::{{constant.identifier}};
+using {{binding.baseNamespace}}::{{constant.identifier}};
 {%- endfor %}
 
 

--- a/khrgenerator/cpp/templates/enumF.h
+++ b/khrgenerator/cpp/templates/enumF.h
@@ -7,7 +7,7 @@
 #include <{{api.identifier}}binding/{{api.identifier}}/enum.h>
 
 
-namespace {{api.identifier}}{{memberSet}}
+namespace {{apiString}}{{memberSet}}
 {
 
 
@@ -21,4 +21,4 @@ using {{api.identifier}}::{{constant.identifier}};
 {%- endfor %}
 
 
-} // namespace {{api.identifier}}{{memberSet}}
+} // namespace {{apiString}}{{memberSet}}

--- a/khrgenerator/cpp/templates/enumF.h
+++ b/khrgenerator/cpp/templates/enumF.h
@@ -2,9 +2,9 @@
 #pragma once
 
 
-#include <{{binding.baseNamespace}}binding/no{{binding.baseNamespace}}.h>
+#include <{{profile.bindingNamespace}}/no{{binding.baseNamespace}}.h>
 
-#include <{{binding.baseNamespace}}binding/{{binding.baseNamespace}}/enum.h>
+#include <{{profile.bindingNamespace}}/{{binding.baseNamespace}}/enum.h>
 
 
 namespace {{apiString}}{{memberSet}}

--- a/khrgenerator/cpp/templates/extension.h
+++ b/khrgenerator/cpp/templates/extension.h
@@ -2,14 +2,14 @@
 #pragma once
 
 
-#include <{{binding.identifier}}/no{{api.identifier}}.h>
+#include <{{binding.identifier}}/no{{binding.baseNamespace}}.h>
 
 
-namespace {{api.identifier}}
+namespace {{binding.baseNamespace}}
 {
 
 
-enum class {{binding.extensionType}} : int // {{binding.extensionType}} is not a type introduced by {{api.identifier | upper}} API so far
+enum class {{binding.extensionType}} : int // {{binding.extensionType}} is not a type introduced by {{binding.baseNamespace | upper}} API so far
 {
     UNKNOWN = -1,
     {% for extension in api.extensions|sort(attribute='identifier') -%}
@@ -18,4 +18,4 @@ enum class {{binding.extensionType}} : int // {{binding.extensionType}} is not a
 };
 
 
-} // namespace {{api.identifier}}
+} // namespace {{binding.baseNamespace}}

--- a/khrgenerator/cpp/templates/functions.cpp
+++ b/khrgenerator/cpp/templates/functions.cpp
@@ -1,10 +1,10 @@
 
 #include "../Binding_pch.h"
 
-#include <{{binding.identifier}}/{{api.identifier}}/functions.h>
+#include <{{binding.identifier}}/{{binding.baseNamespace}}/functions.h>
 
 
-namespace {{api.identifier}}
+namespace {{binding.baseNamespace}}
 {
 
 {% for function in functions|sort(attribute='identifier') %}
@@ -14,4 +14,4 @@ namespace {{api.identifier}}
 }
 {% endfor %}
 
-} // namespace {{api.identifier}}
+} // namespace {{binding.baseNamespace}}

--- a/khrgenerator/cpp/templates/functions.h
+++ b/khrgenerator/cpp/templates/functions.h
@@ -4,11 +4,11 @@
 
 #include <{{binding.identifier}}/{{binding.identifier}}_api.h>
 
-#include <{{binding.identifier}}/no{{api.identifier}}.h>
-#include <{{binding.identifier}}/{{api.identifier}}/types.h>
+#include <{{binding.identifier}}/no{{binding.baseNamespace}}.h>
+#include <{{binding.identifier}}/{{binding.baseNamespace}}/types.h>
 
 
-namespace {{api.identifier}}
+namespace {{binding.baseNamespace}}
 {
 
 
@@ -16,8 +16,8 @@ namespace {{api.identifier}}
 {{binding.apiExport}} {{function.returnType.identifier}} {{function.identifier}}({% for param in function.parameters %}{{ param.type.identifier }} {{ param.name }}{% if not loop.last %}, {% endif %}{% endfor %});
 {% endfor %}
 
-} // namespace {{api.identifier}}
+} // namespace {{binding.baseNamespace}}
 
 
 // Include function patches due to dinstinguished types GLint, GLuint, GLenum, and GLboolean
-#include <{{binding.identifier}}/{{api.identifier}}/functions-patches.h>
+#include <{{binding.identifier}}/{{binding.baseNamespace}}/functions-patches.h>

--- a/khrgenerator/cpp/templates/functionsF.h
+++ b/khrgenerator/cpp/templates/functionsF.h
@@ -2,8 +2,8 @@
 #pragma once
 
 
-#include <{{binding.identifier}}/no{{api.identifier}}.h>
-#include <{{binding.identifier}}/{{api.identifier}}/functions.h>
+#include <{{binding.identifier}}/no{{binding.baseNamespace}}.h>
+#include <{{binding.identifier}}/{{binding.baseNamespace}}/functions.h>
 
 
 namespace {{apiString}}{{memberSet}}
@@ -11,7 +11,7 @@ namespace {{apiString}}{{memberSet}}
 
 // import functions
 {%- for function in functions|sort(attribute='identifier') %}
-using {{api.identifier}}::{{function.identifier}};
+using {{binding.baseNamespace}}::{{function.identifier}};
 {%- endfor %}
 
 } // namespace {{apiString}}{{memberSet}}

--- a/khrgenerator/cpp/templates/functionsF.h
+++ b/khrgenerator/cpp/templates/functionsF.h
@@ -6,7 +6,7 @@
 #include <{{binding.identifier}}/{{api.identifier}}/functions.h>
 
 
-namespace {{api.identifier}}{{memberSet}}
+namespace {{apiString}}{{memberSet}}
 {
 
 // import functions
@@ -14,4 +14,4 @@ namespace {{api.identifier}}{{memberSet}}
 using {{api.identifier}}::{{function.identifier}};
 {%- endfor %}
 
-} // namespace {{api.identifier}}{{memberSet}}
+} // namespace {{apiString}}{{memberSet}}

--- a/khrgenerator/cpp/templates/khrbinding-aux/types_to_string.cpp
+++ b/khrgenerator/cpp/templates/khrbinding-aux/types_to_string.cpp
@@ -11,7 +11,7 @@
 #include "types_to_string_private.h"
 
 
-namespace {{api.identifier}}
+namespace {{binding.baseNamespace}}
 {
 
 {% for group in enumerators|sort(attribute='identifier') %}
@@ -48,7 +48,7 @@ std::ostream & operator<<(std::ostream & stream, const {{group.identifier}} & va
 }
 {% endfor %}
 
-} // namespace {{api.identifier}}
+} // namespace {{binding.baseNamespace}}
 
 
 namespace {{binding.namespace}}
@@ -56,7 +56,7 @@ namespace {{binding.namespace}}
 
 
 template <>
-std::ostream & operator<<(std::ostream & stream, const Value<{{api.identifier}}::{{binding.enumType}}> & value)
+std::ostream & operator<<(std::ostream & stream, const Value<{{binding.baseNamespace}}::{{binding.enumType}}> & value)
 {
     stream << value.value();
 
@@ -64,7 +64,7 @@ std::ostream & operator<<(std::ostream & stream, const Value<{{api.identifier}}:
 }
 
 /*template <>
-std::ostream & operator<<(std::ostream & stream, const Value<{{api.identifier}}::{{binding.bitfieldType}}> & value)
+std::ostream & operator<<(std::ostream & stream, const Value<{{binding.baseNamespace}}::{{binding.bitfieldType}}> & value)
 {
     std::stringstream ss;
     ss << "0x" << std::hex << static_cast<unsigned>(value.value());
@@ -74,7 +74,7 @@ std::ostream & operator<<(std::ostream & stream, const Value<{{api.identifier}}:
 }*/
 
 template <>
-std::ostream & operator<<(std::ostream & stream, const Value<{{api.identifier}}::{{binding.booleanType}}> & value)
+std::ostream & operator<<(std::ostream & stream, const Value<{{binding.baseNamespace}}::{{binding.booleanType}}> & value)
 {
     const auto & name = {{binding.auxNamespace}}::Meta::getString(value.value());
     stream.write(name.c_str(), static_cast<std::streamsize>(name.size()));
@@ -93,7 +93,7 @@ std::ostream & operator<<(std::ostream & stream, const Value<const char *> & val
 
 {% for cStringType in cStringTypes|sort %}
 template <>
-std::ostream & operator<<(std::ostream & stream, const Value<{{api.identifier}}::{{cStringType}} *> & value)
+std::ostream & operator<<(std::ostream & stream, const Value<{{binding.baseNamespace}}::{{cStringType}} *> & value)
 {
     auto s = {{binding.auxNamespace}}::wrapString(reinterpret_cast<const char*>(value.value()));
     stream.write(s.c_str(), static_cast<std::streamsize>(s.size()));
@@ -122,9 +122,9 @@ std::ostream & operator<<(std::ostream & stream, const AbstractValue * value)
     }
 {% endfor -%}
 {% for cPointerType in cPointerTypes|sort %}
-    if (typeid(*value) == typeid(Value<{{api.identifier}}::{{cPointerType}} *>))
+    if (typeid(*value) == typeid(Value<{{binding.baseNamespace}}::{{cPointerType}} *>))
     {
-        return stream << *reinterpret_cast<const Value<{{api.identifier}}::{{cPointerType}} *>*>(value);
+        return stream << *reinterpret_cast<const Value<{{binding.baseNamespace}}::{{cPointerType}} *>*>(value);
     }
 {% endfor -%}
     if (typeid(*value) == typeid(Value<const char *>))
@@ -132,22 +132,22 @@ std::ostream & operator<<(std::ostream & stream, const AbstractValue * value)
         return stream << *reinterpret_cast<const Value<const char *>*>(value);
     }
 {% for cStringType in cStringTypes|sort %}
-    if (typeid(*value) == typeid(Value<{{api.identifier}}::{{cStringType}} *>))
+    if (typeid(*value) == typeid(Value<{{binding.baseNamespace}}::{{cStringType}} *>))
     {
-        return stream << *reinterpret_cast<const Value<{{api.identifier}}::{{cStringType}} *>*>(value);
+        return stream << *reinterpret_cast<const Value<{{binding.baseNamespace}}::{{cStringType}} *>*>(value);
     }
 {% endfor -%}
 {% for type in types|sort(attribute='identifier') %}
     {{ "/*" if type.identifier.endswith("void") or type.identifier.startswith("_") }}
-    if (typeid(*value) == typeid(Value<{{api.identifier}}::{{type.identifier}}>))
+    if (typeid(*value) == typeid(Value<{{binding.baseNamespace}}::{{type.identifier}}>))
     {
-        return stream << *reinterpret_cast<const Value<{{api.identifier}}::{{type.identifier}}>*>(value);
+        return stream << *reinterpret_cast<const Value<{{binding.baseNamespace}}::{{type.identifier}}>*>(value);
     }
     {{ "*/" if type.identifier.endswith("void") or type.identifier.startswith("_") }}
     
-    if (typeid(*value) == typeid(Value<{{api.identifier}}::{{type.identifier}} *>))
+    if (typeid(*value) == typeid(Value<{{binding.baseNamespace}}::{{type.identifier}} *>))
     {
-        return stream << *reinterpret_cast<const Value<{{api.identifier}}::{{type.identifier}} *>*>(value);
+        return stream << *reinterpret_cast<const Value<{{binding.baseNamespace}}::{{type.identifier}} *>*>(value);
     }
 {% endfor %}
     // expect an AbstractValue with a pointer in first member

--- a/khrgenerator/cpp/templates/khrbinding-aux/types_to_string.h
+++ b/khrgenerator/cpp/templates/khrbinding-aux/types_to_string.h
@@ -8,11 +8,11 @@
 #include <{{binding.bindingAuxIdentifier}}/{{binding.bindingAuxIdentifier}}_api.h>
 #include <{{binding.bindingAuxIdentifier}}/{{binding.bindingAuxIdentifier}}_features.h>
 
-#include <{{binding.identifier}}/{{api.identifier}}/types.h>
+#include <{{binding.identifier}}/{{binding.baseNamespace}}/types.h>
 #include <{{binding.identifier}}/Value.h>
 
 
-namespace {{api.identifier}}
+namespace {{binding.baseNamespace}}
 {
 
 
@@ -26,7 +26,7 @@ namespace {{api.identifier}}
 {{binding.auxApiExport}} std::ostream & operator<<(std::ostream & stream, const {{group.identifier}} & value);
 {% endfor %}
 
-} // namespace {{api.identifier}}
+} // namespace {{binding.baseNamespace}}
 
 
 namespace {{binding.namespace}}
@@ -52,24 +52,24 @@ template <typename T>
 
 /**
 *  @brief
-*    A specialized ostream operator for the gl::GLenum Value template
+*    A specialized ostream operator for the {{binding.baseNamespace}}::GLenum Value template
 */
 template <>
-{{binding.auxApiExport}} std::ostream & operator<<(std::ostream & stream, const Value<{{api.identifier}}::{{binding.enumType}}> & value);
+{{binding.auxApiExport}} std::ostream & operator<<(std::ostream & stream, const Value<{{binding.baseNamespace}}::{{binding.enumType}}> & value);
 
 /* <- ToDo: Add back second * when implementing this function again
 *  @brief
-*    A specialized ostream operator for the gl::GLbitfield Value template
+*    A specialized ostream operator for the {{binding.baseNamespace}}::GLbitfield Value template
 */
 /*template <>
-{{binding.auxApiExport}} std::ostream & operator<<(std::ostream & stream, const Value<{{api.identifier}}::{{binding.bitfieldType}}> & value);*/
+{{binding.auxApiExport}} std::ostream & operator<<(std::ostream & stream, const Value<{{binding.baseNamespace}}::{{binding.bitfieldType}}> & value);*/
 
 /**
 *  @brief
-*    A specialized ostream operator for the gl::GLenum Value template
+*    A specialized ostream operator for the {{binding.baseNamespace}}::GLenum Value template
 */
 template <>
-{{binding.auxApiExport}} std::ostream & operator<<(std::ostream & stream, const Value<{{api.identifier}}::{{binding.booleanType}}> & value);
+{{binding.auxApiExport}} std::ostream & operator<<(std::ostream & stream, const Value<{{binding.baseNamespace}}::{{binding.booleanType}}> & value);
 
 /**
 *  @brief
@@ -85,7 +85,7 @@ template <>
 *    A specialized ostream operator for the {{cStringTypeName}} * Value template
 */
 template <>
-{{binding.auxApiExport}} std::ostream & operator<<(std::ostream & stream, const Value<{{api.identifier}}::{{cStringTypeName}} *> & value);
+{{binding.auxApiExport}} std::ostream & operator<<(std::ostream & stream, const Value<{{binding.baseNamespace}}::{{cStringTypeName}} *> & value);
 {%- endfor %}
 
 /**

--- a/khrgenerator/cpp/templates/khrbinding/AbstractFunction.h
+++ b/khrgenerator/cpp/templates/khrbinding/AbstractFunction.h
@@ -35,7 +35,7 @@ public:
     *    Constructor
     *
     *  @param[in] name
-    *    The actual exported OpenGL API function name, including the '{{api.identifier}}' prefix
+    *    The actual exported OpenGL API function name, including the '{{binding.baseNamespace}}' prefix
     */
     AbstractFunction(const char * name);
 
@@ -258,7 +258,7 @@ protected:
 
 
 protected:
-    const char * m_name; ///< The function name, including the '{{api.identifier}}' prefix
+    const char * m_name; ///< The function name, including the '{{binding.baseNamespace}}' prefix
 };
 
 

--- a/khrgenerator/cpp/templates/khrbinding/Function.h
+++ b/khrgenerator/cpp/templates/khrbinding/Function.h
@@ -209,7 +209,7 @@ protected:
 };
 
 
-} // namespace glbinding
+} // namespace {{binding.namespace}}
 
 
 #include <{{binding.identifier}}/Function.inl>

--- a/khrgenerator/cpp/templates/khrbinding/MultiContextBinding.h
+++ b/khrgenerator/cpp/templates/khrbinding/MultiContextBinding.h
@@ -27,7 +27,7 @@ namespace std_boost = std;
 #include <{{binding.identifier}}/FunctionCall.h>
 #include <{{binding.identifier}}/ProcAddress.h>
 
-#include <{{binding.identifier}}/{{api.identifier}}/types.h>
+#include <{{binding.identifier}}/{{binding.baseNamespace}}/types.h>
 
 
 namespace {{binding.namespace}}

--- a/khrgenerator/cpp/templates/khrbinding/SingleContextBinding.h
+++ b/khrgenerator/cpp/templates/khrbinding/SingleContextBinding.h
@@ -27,7 +27,7 @@ namespace std_boost = std;
 #include <{{binding.identifier}}/FunctionCall.h>
 #include <{{binding.identifier}}/ProcAddress.h>
 
-#include <{{binding.identifier}}/{{api.identifier}}/types.h>
+#include <{{binding.identifier}}/{{binding.baseNamespace}}/types.h>
 
 
 namespace {{binding.namespace}}

--- a/khrgenerator/cpp/templates/khrbinding/Version.h
+++ b/khrgenerator/cpp/templates/khrbinding/Version.h
@@ -22,9 +22,9 @@ namespace {{binding.namespace}}
 *
 *  Example code:
 *  @code{.cpp}
-*  const glbinding::Version currentVersion = glbinding::aux::ContextInfo::version();
+*  const {{binding.namespace}}::Version currentVersion = {{binding.namespace}}::aux::ContextInfo::version();
 *
-*  if (currentVersion >= glbinding::Version(3, 2))
+*  if (currentVersion >= {{binding.namespace}}::Version(3, 2))
 *  {
 *      // do something
 *  }

--- a/khrgenerator/cpp/templates/khrbinding/multicontextinterface.h
+++ b/khrgenerator/cpp/templates/khrbinding/multicontextinterface.h
@@ -41,7 +41,7 @@ using ContextSwitchCallback = std::function<void(ContextHandle)>;             //
 *  @remark
 *    This function is a convenience interface for applications that use only one OpenGL context.
 *    If you want to use more than one context, use explicit context identifiers and the dedicated
-*    Initialization interface initialize(ContextHandle, glbinding::GetProcAddress, bool, bool).
+*    Initialization interface initialize(ContextHandle, {{binding.namespace}}::GetProcAddress, bool, bool).
 *
 *  @remark
 *    After this call, the initialized context is already set active for the current thread.

--- a/khrgenerator/cpp/templates/partials/types_addable.h.tpl
+++ b/khrgenerator/cpp/templates/partials/types_addable.h.tpl
@@ -1,5 +1,5 @@
 
-namespace {{api.identifier}}
+namespace {{binding.baseNamespace}}
 {
 
 
@@ -14,4 +14,4 @@ namespace {{api.identifier}}
 }
 
 
-} // namespace {{api.identifier}}
+} // namespace {{binding.baseNamespace}}

--- a/khrgenerator/cpp/templates/partials/types_bitOperatable.h.tpl
+++ b/khrgenerator/cpp/templates/partials/types_bitOperatable.h.tpl
@@ -1,5 +1,5 @@
 
-namespace {{api.identifier}}
+namespace {{binding.baseNamespace}}
 {
 
 
@@ -40,4 +40,4 @@ inline {{identifier}} & operator^=({{identifier}} & a, const {{identifier}} & b)
 }
 
 
-} // namespace {{api.identifier}}
+} // namespace {{binding.baseNamespace}}

--- a/khrgenerator/cpp/templates/partials/types_bitfieldStreamable.cpp.tpl
+++ b/khrgenerator/cpp/templates/partials/types_bitfieldStreamable.cpp.tpl
@@ -1,12 +1,12 @@
-namespace {{api.identifier}}
+namespace {{binding.baseNamespace}}
 {
 
 
 std::ostream & operator<<(std::ostream & stream, const {{identifier}} & value)
 {
-    stream << {{api.identifier}}binding::aux::bitfieldString<{{identifier}}>(value);
+    stream << {{binding.baseNamespace}}binding::aux::bitfieldString<{{identifier}}>(value);
     return stream;
 }
 
 
-} // namespace {{api.identifier}}
+} // namespace {{binding.baseNamespace}}

--- a/khrgenerator/cpp/templates/partials/types_bitfieldStreamable.cpp.tpl
+++ b/khrgenerator/cpp/templates/partials/types_bitfieldStreamable.cpp.tpl
@@ -4,7 +4,7 @@ namespace {{binding.baseNamespace}}
 
 std::ostream & operator<<(std::ostream & stream, const {{identifier}} & value)
 {
-    stream << {{binding.baseNamespace}}binding::aux::bitfieldString<{{identifier}}>(value);
+    stream << {{profile.bindingNamespace}}::aux::bitfieldString<{{identifier}}>(value);
     return stream;
 }
 

--- a/khrgenerator/cpp/templates/partials/types_bitfieldStreamable.h.tpl
+++ b/khrgenerator/cpp/templates/partials/types_bitfieldStreamable.h.tpl
@@ -1,9 +1,9 @@
 
-namespace {{api.identifier}}
+namespace {{binding.baseNamespace}}
 {
 
 
 {{ucapi}}BINDING_AUX_API std::ostream & operator<<(std::ostream & stream, const {{identifier}} & value);
 
 
-} // namespace {{api.identifier}}
+} // namespace {{binding.baseNamespace}}

--- a/khrgenerator/cpp/templates/partials/types_comparable.h.tpl
+++ b/khrgenerator/cpp/templates/partials/types_comparable.h.tpl
@@ -1,4 +1,4 @@
-{{api.identifier}}{{api.identifier}}
+{{binding.baseNamespace}}{{binding.baseNamespace}}
 namespace {{api}}
 {
 

--- a/khrgenerator/cpp/templates/partials/types_hashable.h.tpl
+++ b/khrgenerator/cpp/templates/partials/types_hashable.h.tpl
@@ -4,11 +4,11 @@ namespace std
 
 
 template<>
-struct hash<{{api.identifier}}::{{identifier}}>
+struct hash<{{binding.baseNamespace}}::{{identifier}}>
 {
-    hash<std::underlying_type<{{api.identifier}}::{{identifier}}>::type>::result_type operator()(const {{api.identifier}}::{{identifier}} & t) const
+    hash<std::underlying_type<{{binding.baseNamespace}}::{{identifier}}>::type>::result_type operator()(const {{binding.baseNamespace}}::{{identifier}} & t) const
     {
-        return hash<std::underlying_type<{{api.identifier}}::{{identifier}}>::type>()(static_cast<std::underlying_type<{{api.identifier}}::{{identifier}}>::type>(t));
+        return hash<std::underlying_type<{{binding.baseNamespace}}::{{identifier}}>::type>()(static_cast<std::underlying_type<{{binding.baseNamespace}}::{{identifier}}>::type>(t));
     }
 };
 

--- a/khrgenerator/cpp/templates/partials/types_streamable.cpp.tpl
+++ b/khrgenerator/cpp/templates/partials/types_streamable.cpp.tpl
@@ -1,12 +1,12 @@
-namespace {{api.identifier}}
+namespace {{binding.baseNamespace}}
 {
 
 
 std::ostream & operator<<(std::ostream & stream, const {{identifier}} & value)
 {
-    stream << {{api.identifier}}binding::aux::Meta::getString(value);
+    stream << {{binding.baseNamespace}}binding::aux::Meta::getString(value);
     return stream;
 }
 
 
-} // namespace {{api.identifier}}
+} // namespace {{binding.baseNamespace}}

--- a/khrgenerator/cpp/templates/partials/types_streamable.cpp.tpl
+++ b/khrgenerator/cpp/templates/partials/types_streamable.cpp.tpl
@@ -4,7 +4,7 @@ namespace {{binding.baseNamespace}}
 
 std::ostream & operator<<(std::ostream & stream, const {{identifier}} & value)
 {
-    stream << {{binding.baseNamespace}}binding::aux::Meta::getString(value);
+    stream << {{profile.bindingNamespace}}::aux::Meta::getString(value);
     return stream;
 }
 

--- a/khrgenerator/cpp/templates/partials/types_streamable.h.tpl
+++ b/khrgenerator/cpp/templates/partials/types_streamable.h.tpl
@@ -1,9 +1,9 @@
 
-namespace {{api.identifier}}
+namespace {{binding.baseNamespace}}
 {
 
 
 {{ucapi}}BINDING_AUX_API std::ostream & operator<<(std::ostream & stream, const {{identifier}} & value);
 
 
-} // namespace {{api.identifier}}
+} // namespace {{binding.baseNamespace}}

--- a/khrgenerator/cpp/templates/partials/types_value_output.cpp.tpl
+++ b/khrgenerator/cpp/templates/partials/types_value_output.cpp.tpl
@@ -1,14 +1,14 @@
 {{#integrations.valueRepresentable}}
 {{^isStruct}}
-    if (typeid(*value) == typeid(Value<{{api.identifier}}::{{identifier}}>))
+    if (typeid(*value) == typeid(Value<{{binding.baseNamespace}}::{{identifier}}>))
     {
-        return stream << *reinterpret_cast<const Value<{{api.identifier}}::{{identifier}}>*>(value);
+        return stream << *reinterpret_cast<const Value<{{binding.baseNamespace}}::{{identifier}}>*>(value);
     }
 {{/isStruct}}
-    if (typeid(*value) == typeid(Value<{{api.identifier}}::{{identifier}} *>))
+    if (typeid(*value) == typeid(Value<{{binding.baseNamespace}}::{{identifier}} *>))
     {
-        return stream << *reinterpret_cast<const Value<{{api.identifier}}::{{identifier}} *>*>(value);
+        return stream << *reinterpret_cast<const Value<{{binding.baseNamespace}}::{{identifier}} *>*>(value);
     }
 {{/integrations.valueRepresentable}}{{^integrations.valueRepresentable}}
-    // Omit {{api.identifier}}::{{identifier}}
+    // Omit {{binding.baseNamespace}}::{{identifier}}
 {{/integrations.valueRepresentable}}

--- a/khrgenerator/cpp/templates/revision.h
+++ b/khrgenerator/cpp/templates/revision.h
@@ -6,7 +6,7 @@ namespace {{binding.namespace}}
 {
 
 
-const unsigned int {{api.identifier | upper}}_REVISION = {{api.revision}}; ///< The revision of the {{profile.inputfile}} at the time of code generation.
+const unsigned int {{binding.baseNamespace | upper}}_REVISION = {{api.revision}}; ///< The revision of the {{profile.inputfile}} at the time of code generation.
 
 
 } // namespace {{binding.namespace}}

--- a/khrgenerator/cpp/templates/types.h
+++ b/khrgenerator/cpp/templates/types.h
@@ -19,13 +19,13 @@
 #define {{binding.apientry}}
 #endif
 
-#include <{{binding.identifier}}/no{{api.identifier}}.h>
+#include <{{binding.identifier}}/no{{binding.baseNamespace}}.h>
 #include <{{binding.identifier}}/{{binding.identifier}}_api.h>
 #include <{{binding.identifier}}/{{binding.identifier}}_features.h>
-#include <{{binding.identifier}}/{{api.identifier}}/boolean.h>
+#include <{{binding.identifier}}/{{binding.baseNamespace}}/boolean.h>
 
 
-namespace {{api.identifier}}
+namespace {{binding.baseNamespace}}
 {
 
 {% for type in types|sort(attribute='identifier')|sort(attribute='relevance') %}
@@ -33,7 +33,7 @@ namespace {{api.identifier}}
 {%- endfor %}
 
 
-} // namespace {{api.identifier}}
+} // namespace {{binding.baseNamespace}}
 
 
-#include <{{binding.identifier}}/{{api.identifier}}/types.inl>
+#include <{{binding.identifier}}/{{binding.baseNamespace}}/types.inl>

--- a/khrgenerator/cpp/templates/types.inl
+++ b/khrgenerator/cpp/templates/types.inl
@@ -2,7 +2,7 @@
 #pragma once
 
 
-#include <{{binding.identifier}}/{{api.identifier}}/types.h>
+#include <{{binding.identifier}}/{{binding.baseNamespace}}/types.h>
 
 
 {% for group in basic_enumerators|sort(attribute='identifier') -%}
@@ -11,11 +11,11 @@ namespace std
 
 
 template<>
-struct hash<{{api.identifier}}::{{group.identifier}}>
+struct hash<{{binding.baseNamespace}}::{{group.identifier}}>
 {
-    std::size_t operator()(const {{api.identifier}}::{{group.identifier}} & t) const
+    std::size_t operator()(const {{binding.baseNamespace}}::{{group.identifier}} & t) const
     {
-        return hash<std::underlying_type<{{api.identifier}}::{{group.identifier}}>::type>()(static_cast<std::underlying_type<{{api.identifier}}::{{group.identifier}}>::type>(t));
+        return hash<std::underlying_type<{{binding.baseNamespace}}::{{group.identifier}}>::type>()(static_cast<std::underlying_type<{{binding.baseNamespace}}::{{group.identifier}}>::type>(t));
     }
 };
 
@@ -30,11 +30,11 @@ namespace std
 
 
 template<>
-struct hash<{{api.identifier}}::{{group.identifier}}>
+struct hash<{{binding.baseNamespace}}::{{group.identifier}}>
 {
-    std::size_t operator()(const {{api.identifier}}::{{group.identifier}} & t) const
+    std::size_t operator()(const {{binding.baseNamespace}}::{{group.identifier}} & t) const
     {
-        return hash<std::underlying_type<{{api.identifier}}::{{group.identifier}}>::type>()(static_cast<std::underlying_type<{{api.identifier}}::{{group.identifier}}>::type>(t));
+        return hash<std::underlying_type<{{binding.baseNamespace}}::{{group.identifier}}>::type>()(static_cast<std::underlying_type<{{binding.baseNamespace}}::{{group.identifier}}>::type>(t));
     }
 };
 
@@ -42,7 +42,7 @@ struct hash<{{api.identifier}}::{{group.identifier}}>
 } // namespace std
 
 
-namespace {{api.identifier}}
+namespace {{binding.baseNamespace}}
 {
 
 
@@ -117,7 +117,7 @@ namespace {{api.identifier}}
 }
 
 
-} // namespace {{api.identifier}}
+} // namespace {{binding.baseNamespace}}
 {%- endfor %}
 
 
@@ -129,11 +129,11 @@ namespace std
 
 
 template<>
-struct hash<{{api.identifier}}::{{group.identifier}}>
+struct hash<{{binding.baseNamespace}}::{{group.identifier}}>
 {
-    std::size_t operator()(const {{api.identifier}}::{{group.identifier}} & t) const
+    std::size_t operator()(const {{binding.baseNamespace}}::{{group.identifier}} & t) const
     {
-        return hash<std::underlying_type<{{api.identifier}}::{{group.identifier}}>::type>()(static_cast<std::underlying_type<{{api.identifier}}::{{group.identifier}}>::type>(t));
+        return hash<std::underlying_type<{{binding.baseNamespace}}::{{group.identifier}}>::type>()(static_cast<std::underlying_type<{{binding.baseNamespace}}::{{group.identifier}}>::type>(t));
     }
 };
 
@@ -141,7 +141,7 @@ struct hash<{{api.identifier}}::{{group.identifier}}>
 } // namespace std
 
 
-namespace {{api.identifier}}
+namespace {{binding.baseNamespace}}
 {
 
 
@@ -182,5 +182,5 @@ inline {{group.identifier}} & operator^=({{group.identifier}} & a, const {{group
 }
 
 
-} // namespace {{api.identifier}}
+} // namespace {{binding.baseNamespace}}
 {%- endfor %}

--- a/khrgenerator/cpp/templates/typesF.h
+++ b/khrgenerator/cpp/templates/typesF.h
@@ -6,7 +6,7 @@
 #include <{{api.identifier}}binding/{{api.identifier}}/types.h>
 
 
-namespace {{api.identifier}}{{memberSet}}
+namespace {{apiString}}{{memberSet}}
 {
 
 
@@ -15,4 +15,4 @@ using {{api.identifier}}::{{type.identifier}};
 {%- endfor %}
 
 
-} // namespace {{api.identifier}}{{memberSet}}
+} // namespace {{apiString}}{{memberSet}}

--- a/khrgenerator/cpp/templates/typesF.h
+++ b/khrgenerator/cpp/templates/typesF.h
@@ -2,8 +2,8 @@
 #pragma once
 
 
-#include <{{api.identifier}}binding/no{{api.identifier}}.h>
-#include <{{api.identifier}}binding/{{api.identifier}}/types.h>
+#include <{{binding.baseNamespace}}binding/no{{binding.baseNamespace}}.h>
+#include <{{binding.baseNamespace}}binding/{{binding.baseNamespace}}/types.h>
 
 
 namespace {{apiString}}{{memberSet}}
@@ -11,7 +11,7 @@ namespace {{apiString}}{{memberSet}}
 
 
 {% for type in types|sort(attribute='identifier') %}
-using {{api.identifier}}::{{type.identifier}};
+using {{binding.baseNamespace}}::{{type.identifier}};
 {%- endfor %}
 
 

--- a/khrgenerator/cpp/templates/typesF.h
+++ b/khrgenerator/cpp/templates/typesF.h
@@ -2,8 +2,8 @@
 #pragma once
 
 
-#include <{{binding.baseNamespace}}binding/no{{binding.baseNamespace}}.h>
-#include <{{binding.baseNamespace}}binding/{{binding.baseNamespace}}/types.h>
+#include <{{profile.bindingNamespace}}/no{{binding.baseNamespace}}.h>
+#include <{{profile.bindingNamespace}}/{{binding.baseNamespace}}/types.h>
 
 
 namespace {{apiString}}{{memberSet}}

--- a/khrgenerator/cpp/templates/values.h
+++ b/khrgenerator/cpp/templates/values.h
@@ -4,11 +4,11 @@
 
 #include <{{binding.identifier}}/{{binding.identifier}}_features.h>
 
-#include <{{binding.identifier}}/no{{api.identifier}}.h>
-#include <{{binding.identifier}}/{{api.identifier}}/types.h>
+#include <{{binding.identifier}}/no{{binding.baseNamespace}}.h>
+#include <{{binding.identifier}}/{{binding.baseNamespace}}/types.h>
 
 
-namespace {{api.identifier}}
+namespace {{binding.baseNamespace}}
 {
 
 
@@ -16,4 +16,4 @@ namespace {{api.identifier}}
 {{binding.constexpr}} static const {{constant.type.identifier}} {{constant.identifier}} = {{constant.value}};
 {% endfor %}
 
-} // namespace {{api.identifier}}
+} // namespace {{binding.baseNamespace}}

--- a/khrgenerator/cpp/templates/valuesF.h
+++ b/khrgenerator/cpp/templates/valuesF.h
@@ -2,9 +2,9 @@
 #pragma once
 
 
-#include <{{api.identifier}}binding/no{{api.identifier}}.h>
+#include <{{binding.baseNamespace}}binding/no{{binding.baseNamespace}}.h>
 
-#include <{{api.identifier}}binding/{{api.identifier}}/values.h>
+#include <{{binding.baseNamespace}}binding/{{binding.baseNamespace}}/values.h>
 
 
 namespace {{apiString}}{{memberSet}}
@@ -13,7 +13,7 @@ namespace {{apiString}}{{memberSet}}
 
 // import values to namespace
 {%- for value in values|sort(attribute='identifier') %}
-using {{api.identifier}}::{{value.identifier}};
+using {{binding.baseNamespace}}::{{value.identifier}};
 {%- endfor %}
 
 

--- a/khrgenerator/cpp/templates/valuesF.h
+++ b/khrgenerator/cpp/templates/valuesF.h
@@ -7,7 +7,7 @@
 #include <{{api.identifier}}binding/{{api.identifier}}/values.h>
 
 
-namespace {{api.identifier}}{{memberSet}}
+namespace {{apiString}}{{memberSet}}
 {
 
 
@@ -17,4 +17,4 @@ using {{api.identifier}}::{{value.identifier}};
 {%- endfor %}
 
 
-} // namespace {{api.identifier}}{{memberSet}}
+} // namespace {{apiString}}{{memberSet}}

--- a/khrgenerator/cpp/templates/valuesF.h
+++ b/khrgenerator/cpp/templates/valuesF.h
@@ -2,9 +2,9 @@
 #pragma once
 
 
-#include <{{binding.baseNamespace}}binding/no{{binding.baseNamespace}}.h>
+#include <{{profile.bindingNamespace}}/no{{binding.baseNamespace}}.h>
 
-#include <{{binding.baseNamespace}}binding/{{binding.baseNamespace}}/values.h>
+#include <{{profile.bindingNamespace}}/{{binding.baseNamespace}}/values.h>
 
 
 namespace {{apiString}}{{memberSet}}

--- a/khrparser/Profile.py
+++ b/khrparser/Profile.py
@@ -11,16 +11,12 @@ class Profile:
 
         self.lowercasePrefix = jsonObject["lowercasePrefix"]
         self.uppercasePrefix = jsonObject["uppercasePrefix"]
-
-        self.api = jsonObject["baseNamespace"]
         self.baseNamespace = jsonObject["baseNamespace"]
         self.inputfilepath = jsonObject["sourceFile"]
         self.inputfile = os.path.basename(self.inputfilepath)
-        self.apiIdentifier = jsonObject["apiIdentifier"]
         self.multiContextBinding = jsonObject["multiContext"]
         self.booleanWidth = jsonObject["booleanWidth"]
         self.bindingNamespace = jsonObject["bindingNamespace"]
-        self.minCoreVersion = jsonObject["coreProfileSince"]
         self.extensionType = jsonObject["extensionType"]
         self.noneBitfieldValue = jsonObject["noneBitfieldValue"]
         self.useEnumGroups = jsonObject["useEnumGroups"]
@@ -32,3 +28,19 @@ class Profile:
         self.cStringOutputTypes = jsonObject["cStringOutputTypes"]
         self.generateNoneBits = jsonObject["generateNoneBits"]
         self.undefs = jsonObject["undefs"] if "undefs" in jsonObject else []
+
+        if "apis" in jsonObject and isinstance(jsonObject["apis"], list):
+            self.apis = { api["identifier"]: { "entryPointHeader": api["entryPointHeader"] } for api in jsonObject["apis"] }
+            for api in jsonObject["apis"]:
+                if "coreProfileSince" in api:
+                    self.apis[api["identifier"]]["coreProfileSince"] = api["coreProfileSince"]
+
+        # Compatibility with old profile JSON format:
+        elif jsonObject["apiIdentifier"]:
+            api = {
+                "identifier": jsonObject["apiIdentifier"],
+                "entryPointHeader": self.baseNamespace
+            }
+            if jsonObject["coreProfileSince"]:
+                api["coreProfileSince"] = jsonObject["coreProfileSince"]
+            self.apis = [api]

--- a/khrparser/Profile.py
+++ b/khrparser/Profile.py
@@ -20,7 +20,7 @@ class Profile:
         self.multiContextBinding = jsonObject["multiContext"]
         self.booleanWidth = jsonObject["booleanWidth"]
         self.bindingNamespace = jsonObject["bindingNamespace"]
-        self.minCoreVersion = [ int(number) for number in jsonObject["coreProfileSince"].split(".") ] if jsonObject["coreProfileSince"] is not None else None
+        self.minCoreVersion = jsonObject["coreProfileSince"]
         self.extensionType = jsonObject["extensionType"]
         self.noneBitfieldValue = jsonObject["noneBitfieldValue"]
         self.useEnumGroups = jsonObject["useEnumGroups"]

--- a/khrparser/Profile.py
+++ b/khrparser/Profile.py
@@ -27,6 +27,7 @@ class Profile:
         self.headerReplacement = jsonObject["headerReplacement"]
         self.cStringOutputTypes = jsonObject["cStringOutputTypes"]
         self.generateNoneBits = jsonObject["generateNoneBits"]
+        self.stripFeatureHeaders = jsonObject["stripFeatureHeaders"] if "stripFeatureHeaders" in jsonObject else False
         self.undefs = jsonObject["undefs"] if "undefs" in jsonObject else []
 
         if "apis" in jsonObject and isinstance(jsonObject["apis"], list):
@@ -37,10 +38,7 @@ class Profile:
 
         # Compatibility with old profile JSON format:
         elif jsonObject["apiIdentifier"]:
-            api = {
-                "identifier": jsonObject["apiIdentifier"],
-                "entryPointHeader": self.baseNamespace
-            }
+            self.apis = { jsonObject["apiIdentifier"]: { "entryPointHeader": self.baseNamespace } }
             if jsonObject["coreProfileSince"]:
-                api["coreProfileSince"] = jsonObject["coreProfileSince"]
-            self.apis = [api]
+                self.apis[jsonObject["apiIdentifier"]]["coreProfileSince"] = jsonObject["coreProfileSince"]
+                

--- a/khrparser/Profile.py
+++ b/khrparser/Profile.py
@@ -38,7 +38,7 @@ class Profile:
 
         # Compatibility with old profile JSON format:
         elif jsonObject["apiIdentifier"]:
-            self.apis = { jsonObject["apiIdentifier"]: { "entryPointHeader": self.baseNamespace } }
+            self.apis = { jsonObject["apiIdentifier"]: { "entryPointHeader": f"{self.baseNamespace}.h" } }
             if jsonObject["coreProfileSince"]:
                 self.apis[jsonObject["apiIdentifier"]]["coreProfileSince"] = jsonObject["coreProfileSince"]
                 

--- a/khrparser/XMLParser.py
+++ b/khrparser/XMLParser.py
@@ -15,13 +15,12 @@ class XMLParser:
 
         revision_date = datetime.datetime.fromtimestamp(os.path.getmtime(xmlFile))
         revision_string = revision_date.strftime('%Y%m%d')
-        
-        api = API(profile.api, revision_string)
+
+        api = API(profile.baseNamespace, revision_string)
         
         tree = xml.etree.ElementTree.parse(xmlFile)
 
         cls.parseXML(api, profile, tree.getroot())
-
         return api
 
     @classmethod

--- a/khrparser/an/ANParser.py
+++ b/khrparser/an/ANParser.py
@@ -175,7 +175,6 @@ class ANParser(XMLParser):
         binding.baseNamespace = profile.baseNamespace
         
         binding.multiContextBinding = profile.multiContextBinding
-        binding.minCoreVersion = profile.minCoreVersion
         
         binding.identifier = profile.bindingNamespace
         binding.namespace = profile.bindingNamespace
@@ -190,7 +189,7 @@ class ANParser(XMLParser):
         binding.constexpr = binding.identifier.upper() + "_CONSTEXPR"
         binding.threadlocal = binding.identifier.upper() + "_THREAD_LOCAL"
         binding.useboostthread = binding.identifier.upper() + "_USE_BOOST_THREAD"
-        binding.apientry = api.identifier.upper()+"_APIENTRY"
+        binding.apientry = binding.baseNamespace.upper()+"_APIENTRY"
 
         binding.headerGuardMacro = profile.headerGuardMacro
         binding.headerReplacement = profile.headerReplacement

--- a/khrparser/an/ANParser.py
+++ b/khrparser/an/ANParser.py
@@ -622,7 +622,7 @@ class ANParser(XMLParser):
         """
 
         identifier = "an"+"".join([ c for c in feature.attrib["number"] if c.isdigit() ])
-        version = Version(api, identifier, feature.attrib["name"], feature.attrib["number"], "an")
+        version = Version(api, identifier, feature.attrib["api"], feature.attrib["number"], "an")
 
         for require in feature.findall("require"):
             cls.handleVersionRequire(api, version, require)

--- a/khrparser/egl/EGLParser.py
+++ b/khrparser/egl/EGLParser.py
@@ -101,7 +101,7 @@ class EGLParser(XMLParser):
                 try:
                     constant.decimalValue = int(enum.attrib["value"], 0)
                 except:
-                    castResult = re.search('EGL_CAST\(%s[A-Za-z0-9_]+\,([\-0-9]+)\)', enum.attrib["value"])
+                    castResult = re.search(r'EGL_CAST\(%s[A-Za-z0-9_]+\,([\-0-9]+)\)', enum.attrib["value"])
                     if castResult is not None:
                         constant.decimalValue = castResult.group(1).strip()
                     else:
@@ -477,7 +477,7 @@ class EGLParser(XMLParser):
                 return api.typeByIdentifier("EGLuint64KHR")
         
         if "value" in enum.attrib:
-            castResult = re.search('%s([A-Za-z0-9_]+)' % ("EGL_CAST\("), enum.attrib["value"])
+            castResult = re.search(r'%s([A-Za-z0-9_]+)' % (r'EGL_CAST\('), enum.attrib["value"])
             if castResult is not None:
                 typeName = castResult.group(1).strip()
                 return next((t for t in api.types if t.identifier.endswith(typeName)), api.typeByIdentifier("EGLint"))

--- a/khrparser/egl/EGLParser.py
+++ b/khrparser/egl/EGLParser.py
@@ -435,7 +435,6 @@ class EGLParser(XMLParser):
         binding.baseNamespace = profile.baseNamespace
         
         binding.multiContextBinding = profile.multiContextBinding
-        binding.minCoreVersion = profile.minCoreVersion
         
         binding.identifier = profile.bindingNamespace
         binding.namespace = profile.bindingNamespace
@@ -450,7 +449,7 @@ class EGLParser(XMLParser):
         binding.constexpr = binding.identifier.upper() + "_CONSTEXPR"
         binding.threadlocal = binding.identifier.upper() + "_THREAD_LOCAL"
         binding.useboostthread = binding.identifier.upper() + "_USE_BOOST_THREAD"
-        binding.apientry = api.identifier.upper()+"_APIENTRY"
+        binding.apientry = binding.baseNamespace.upper()+"_APIENTRY"
 
         binding.additionalTypes = ""
         

--- a/khrparser/egl/EGLParser.py
+++ b/khrparser/egl/EGLParser.py
@@ -303,10 +303,11 @@ class EGLParser(XMLParser):
 
         featureSets = []
 
-        api.versions = [ version for version in api.versions if profile.apiIdentifier in version.supportedAPIs ]
+        identifiers = set(profile.apis.keys())
+        api.versions = [ version for version in api.versions if any([api in version.supportedAPIs for api in identifiers]) ]
         featureSets += api.versions
 
-        api.extensions = [ extension for extension in api.extensions if profile.apiIdentifier in extension.supportedAPIs ]
+        api.extensions = [ extension for extension in api.extensions if any([api in extension.supportedAPIs for api in identifiers]) ]
         featureSets += api.extensions
 
         api.constants = [ constant for constant in api.constants if

--- a/khrparser/gl/GLParser.py
+++ b/khrparser/gl/GLParser.py
@@ -19,8 +19,6 @@ from khrapi.Constant import Constant
 from khrapi.Function import Function
 from khrapi.Parameter import Parameter
 
-import collections.abc
-
 class GLParser(XMLParser):
 
     @classmethod
@@ -275,13 +273,9 @@ class GLParser(XMLParser):
 
         featureSets = []
 
-        mixedAPIs = not isinstance(profile.apiIdentifier, str) and isinstance(profile.apiIdentifier, collections.abc.Sequence)
-        if mixedAPIs:
-            api.versions = [ version for version in api.versions if any([apiIdentifier in version.supportedAPIs for apiIdentifier in profile.apiIdentifier]) ]
-            api.extensions = [ extension for extension in api.extensions if any([apiIdentifier in extension.supportedAPIs for apiIdentifier in profile.apiIdentifier]) ]
-        else:
-            api.versions = [ version for version in api.versions if profile.apiIdentifier in version.supportedAPIs ]
-            api.extensions = [ extension for extension in api.extensions if profile.apiIdentifier in extension.supportedAPIs ]
+        identifiers = set(profile.apis.keys())
+        api.versions = [ version for version in api.versions if any([api in version.supportedAPIs for api in identifiers]) ]
+        api.extensions = [ extension for extension in api.extensions if any([api in extension.supportedAPIs for api in identifiers]) ]
             
         featureSets += api.versions
         featureSets += api.extensions
@@ -411,7 +405,6 @@ class GLParser(XMLParser):
         binding.baseNamespace = profile.baseNamespace
         
         binding.multiContextBinding = profile.multiContextBinding
-        binding.minCoreVersion = profile.minCoreVersion
         
         binding.identifier = profile.bindingNamespace
         binding.namespace = profile.bindingNamespace
@@ -426,7 +419,7 @@ class GLParser(XMLParser):
         binding.constexpr = binding.identifier.upper() + "_CONSTEXPR"
         binding.threadlocal = binding.identifier.upper() + "_THREAD_LOCAL"
         binding.useboostthread = binding.identifier.upper() + "_USE_BOOST_THREAD"
-        binding.apientry = api.identifier.upper()+"_APIENTRY"
+        binding.apientry = profile.baseNamespace.upper()+"_APIENTRY"
 
         binding.headerGuardMacro = profile.headerGuardMacro
         binding.headerReplacement = profile.headerReplacement
@@ -505,7 +498,7 @@ class GLParser(XMLParser):
     @classmethod
     def ensureGLES2Types(cls, api, profile):
         # Add missing types
-        if profile.apiIdentifier == "gles2":
+        if "gles2" in profile.apis.keys():
             intType = api.typeByIdentifier('int')
             if intType is None:
                 intType = NativeType(api, "int", "int")

--- a/khrparser/gl/GLParser.py
+++ b/khrparser/gl/GLParser.py
@@ -19,6 +19,8 @@ from khrapi.Constant import Constant
 from khrapi.Function import Function
 from khrapi.Parameter import Parameter
 
+import collections.abc
+
 class GLParser(XMLParser):
 
     @classmethod
@@ -273,10 +275,15 @@ class GLParser(XMLParser):
 
         featureSets = []
 
-        api.versions = [ version for version in api.versions if profile.apiIdentifier in version.supportedAPIs ]
+        mixedAPIs = not isinstance(profile.apiIdentifier, str) and isinstance(profile.apiIdentifier, collections.abc.Sequence)
+        if mixedAPIs:
+            api.versions = [ version for version in api.versions if any([apiIdentifier in version.supportedAPIs for apiIdentifier in profile.apiIdentifier]) ]
+            api.extensions = [ extension for extension in api.extensions if any([apiIdentifier in extension.supportedAPIs for apiIdentifier in profile.apiIdentifier]) ]
+        else:
+            api.versions = [ version for version in api.versions if profile.apiIdentifier in version.supportedAPIs ]
+            api.extensions = [ extension for extension in api.extensions if profile.apiIdentifier in extension.supportedAPIs ]
+            
         featureSets += api.versions
-
-        api.extensions = [ extension for extension in api.extensions if profile.apiIdentifier in extension.supportedAPIs ]
         featureSets += api.extensions
 
         api.constants = [ constant for constant in api.constants if

--- a/khrparser/vk/VKParser.py
+++ b/khrparser/vk/VKParser.py
@@ -258,7 +258,6 @@ class VKParser(XMLParser):
         binding.baseNamespace = profile.baseNamespace
         
         binding.multiContextBinding = profile.multiContextBinding
-        binding.minCoreVersion = profile.minCoreVersion
         
         binding.identifier = profile.bindingNamespace
         binding.namespace = profile.bindingNamespace
@@ -273,7 +272,7 @@ class VKParser(XMLParser):
         binding.constexpr = binding.identifier.upper() + "_CONSTEXPR"
         binding.threadlocal = binding.identifier.upper() + "_THREAD_LOCAL"
         binding.useboostthread = binding.identifier.upper() + "_USE_BOOST_THREAD"
-        binding.apientry = api.identifier.upper()+"_APIENTRY"
+        binding.apientry = binding.baseNamespace.upper()+"_APIENTRY"
 
         binding.headerGuardMacro = profile.headerGuardMacro
         binding.headerReplacement = profile.headerReplacement

--- a/khrparser/vk/VKParser.py
+++ b/khrparser/vk/VKParser.py
@@ -85,7 +85,8 @@ class VKParser(XMLParser):
 
         featureSets = []
 
-        api.versions = [ version for version in api.versions if profile.apiIdentifier in version.supportedAPIs ]
+        identifiers = set(profile.apis.keys())
+        api.versions = [ version for version in api.versions if any([api in version.supportedAPIs for api in identifiers]) ]
         featureSets += api.versions
 
         # filter extensions
@@ -93,7 +94,7 @@ class VKParser(XMLParser):
             extension.platform == "" and
             not extension.identifier.startswith('RESERVED_DO_NOT_USE') and
             not "_extension_" in extension.identifier and
-            profile.apiIdentifier in extension.supportedAPIs
+            any([api in extension.supportedAPIs for api in identifiers])
         ]
         featureSets += api.extensions
 
@@ -569,7 +570,7 @@ class VKParser(XMLParser):
     @classmethod
     def handleVersion(cls, api, profile, feature):
         identifier = "vk"+"".join([ c for c in feature.attrib["number"] if c.isdigit() ])
-        version = Version(api, identifier, feature.attrib["name"], feature.attrib["number"], "vk")
+        version = Version(api, identifier, feature.attrib["api"], feature.attrib["number"], "vk")
 
         for require in feature.findall("require"):
             cls.handleVersionRequire(api, version, require)

--- a/profiles/gl+gles.json
+++ b/profiles/gl+gles.json
@@ -22,9 +22,10 @@
 	"generateStringConversion": true,
 	"generateCallbacks": true,
 	"generateLogging": true,
+	"stripFeatureHeaders": true,
 	"generateHeaderGuard": true,
-	"headerGuardMacro": [ "__gl_h_" ],
-	"headerReplacement": [ "gl.h" ],
+	"headerGuardMacro": [ "__gl_h_", "__gles_h_", "__gles1_h_", "__gles2_h_", "__gles3_h_" ],
+	"headerReplacement": [ "gl.h", "gles.h", "gles1.h", "gles2.h", "gles3.h" ],
 
 	"": "Types",
 	"extensionType": "GLextension",
@@ -36,7 +37,21 @@
 	"cStringOutputTypes": [ "GLubyte", "GLchar" ],
 
 	"": "API Feature management",
-	"apiIdentifier": "gl",
+	"apis": [
+		{
+			"identifier": "gl",
+			"coreProfileSince": "3.2",
+			"entryPointHeader": "gl.h"
+		},
+		{
+			"identifier": "gles1",
+			"entryPointHeader": "gles.h"
+		},
+		{
+			"identifier": "gles2",
+			"entryPointHeader": "gles.h"
+		}
+	],
 	"versions": [],
 	"featureBlacklist": [],
 	"extensionBlacklist": [],

--- a/profiles/gl.json
+++ b/profiles/gl.json
@@ -22,9 +22,10 @@
 	"generateStringConversion": true,
 	"generateCallbacks": true,
 	"generateLogging": true,
+	"stripFeatureHeaders": true,
 	"generateHeaderGuard": true,
-	"headerGuardMacro": [ "__gl_h_" ],
-	"headerReplacement": [ "gl.h" ],
+	"headerGuardMacro": [ "__gl_h_", "__gles_h_", "__gles1_h_", "__gles2_h_", "__gles3_h_" ],
+	"headerReplacement": [ "gl.h", "gles.h", "gles1.h", "gles2.h", "gles3.h" ],
 
 	"": "Types",
 	"extensionType": "GLextension",
@@ -36,7 +37,21 @@
 	"cStringOutputTypes": [ "GLubyte", "GLchar" ],
 
 	"": "API Feature management",
-	"apiIdentifier": "gl",
+	"apis": [
+		{
+			"identifier": "gl",
+			"coreProfileSince": "3.2",
+			"entryPointHeader": "gl.h"
+		},
+		{
+			"identifier": "gles1",
+			"entryPointHeader": "gles.h"
+		},
+		{
+			"identifier": "gles2",
+			"entryPointHeader": "gles.h"
+		}
+	],
 	"versions": [],
 	"featureBlacklist": [],
 	"extensionBlacklist": [],


### PR DESCRIPTION
Hello!,

I was working on a project which requires switching between OpenGL and OpenGL ES bindings on runtime and I was struggling to find a library that could support this. I was using both [glbinding](https://github.com/cginternals/glbinding) and [glesbinding](https://github.com/cginternals/glesbinding), but they clash on compiling/linking as they expose the same symbols. However, I noticed that they could probably be combined somehow. So I've done some "hacks" to combine them for these binding generator scripts and I've been testing it out in this fork: [andesyv/glmixedbinding](https://github.com/andesyv/glmixedbinding)

Combining the symbols from OpenGL and OpenGL ES created another issue however, in that types from OpenGL ES bleed into the type declarations for OpenGL Core/Compatibility (specifically the EGL related type declarations included in the OpenGL ES standard). So I've attempted to solve this by additionally stripping down the types exposed in the versioned headers (`glbinding/gl33/types.h`, `glbinding/gl43ext/types.h`, `glbinding/gles31/types.h`, e.t.c.). But for safety or compatibility with current projects relying on glbinding, I've set this "type stripping" configurable with a `stripFeatureHeaders` field in the profile JSON.

Hopefully this (at least partially) closes #6.